### PR TITLE
Fix stream seek and increase stack size of injected thread

### DIFF
--- a/src/qnx/qinjector.vala
+++ b/src/qnx/qinjector.vala
@@ -180,9 +180,9 @@ namespace Frida {
 
 		private void reset_stream (InputStream stream) {
 			try {
-				(stream as Seekable).seek (0, SeekType.END);
+				(stream as Seekable).seek (0, SeekType.SET);
 			} catch (GLib.Error e) {
-				//assert_not_reached ();
+				assert_not_reached ();
 			}
 		}
 	}


### PR DESCRIPTION
This fixes the stream seek which was unintentionally changed to SeekType.END in an earlier commit.

It also increases the stack size of the injected stack to 2Mb so that v8 has some room to breath.