### PR TITLE
Support enumerating apps on OS X

### DIFF
--- a/src/darwin/system-darwin.m
+++ b/src/darwin/system-darwin.m
@@ -176,6 +176,8 @@ frida_system_enumerate_applications (int * result_length)
     i++;
   }
 
+  result = g_renew (FridaHostApplicationInfo, result, i);
+
   [pool release];
 
   *result_length = i;


### PR DESCRIPTION
The `[query startQuery];` should be run from the main thread according to Apple's docs, however this code works for at least `frida-ps -a`. (Maybe in this case the code is already running in the main thread?)

I'm not sure what we should do when multiple apps have the same bundle identifier.
