### PR TITLE
Fix for compiler messages

### DIFF
--- a/src/linux/system-linux.c
+++ b/src/linux/system-linux.c
@@ -66,7 +66,7 @@ frida_system_enumerate_applications (int * result_length)
     }
 
     g_array_set_size (applications, applications->len + 1);
-    info = &g_array_index (applications, FridaHostProcessInfo, applications->len - 1);
+    info = &g_array_index (applications, FridaHostApplicationInfo, applications->len - 1);
     info->_identifier = app_id;
     info->_name = app_name;
     info->_pid = pid;
@@ -78,7 +78,7 @@ frida_system_enumerate_applications (int * result_length)
 
   *result_length = applications->len;
 
-  return g_array_free (applications, FALSE);
+  return (FridaHostApplicationInfo *) g_array_free (applications, FALSE);
 }
 
 FridaHostProcessInfo *
@@ -136,7 +136,7 @@ frida_system_enumerate_processes (int * result_length)
 
   *result_length = processes->len;
 
-  return g_array_free (processes, FALSE);
+  return (FridaHostProcessInfo *) g_array_free (processes, FALSE);
 }
 
 void


### PR DESCRIPTION
```
../../../../frida-core/src/linux/system-linux.c: In function 'frida_system_enumerate_applications':
../../../../frida-core/src/linux/system-linux.c:69:10: warning: assignment from incompatible pointer type [-Wincompatible-pointer-types]
     info = &g_array_index (applications, FridaHostProcessInfo, applications->len - 1);
          ^
../../../../frida-core/src/linux/system-linux.c:81:10: warning: return from incompatible pointer type [-Wincompatible-pointer-types]
   return g_array_free (applications, FALSE);
          ^
../../../../frida-core/src/linux/system-linux.c: In function 'frida_system_enumerate_processes':
../../../../frida-core/src/linux/system-linux.c:139:10: warning: return from incompatible pointer type [-Wincompatible-pointer-types]
   return g_array_free (processes, FALSE);
```