### PR TITLE
Fix bug when hooking pthread_create before it has been properly resol…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,7 @@ case $host_os in
 esac
 if [[ "x$HAVE_LINUX" = "xyes" ]]; then
   AC_DEFINE(HAVE_LINUX, 1, [Define to 1 if OS is Linux based.])
+  AC_DEFINE(_GNU_SOURCE, 1, [Enable GNU extensions (required by Linux backend).])
 fi
 if [[ "x$HAVE_DARWIN" = "xyes" ]]; then
   AC_DEFINE(HAVE_DARWIN, 1, [Define to 1 if OS is Darwin based.])

--- a/lib/agent/agent-glue.c
+++ b/lib/agent/agent-glue.c
@@ -502,7 +502,7 @@ frida_get_address_of_thread_create_func (void)
 #ifdef G_OS_WIN32
   return GUM_FUNCPTR_TO_POINTER (_beginthreadex);
 #else
-  return GUM_FUNCPTR_TO_POINTER (pthread_create);
+  return dlsym (-1, "pthread_create");
 #endif
 }
 

--- a/lib/agent/agent-glue.c
+++ b/lib/agent/agent-glue.c
@@ -502,7 +502,7 @@ frida_get_address_of_thread_create_func (void)
 #ifdef G_OS_WIN32
   return GUM_FUNCPTR_TO_POINTER (_beginthreadex);
 #else
-  return dlsym (-1, "pthread_create");
+  return dlsym (RTLD_NEXT, "pthread_create");
 #endif
 }
 


### PR DESCRIPTION
…ved by the target application.

The bug is that we end up hooking the dynamic linker stub, instead of pthread_create. We will then get spurious calls to our replacement pthread_create when the application tries to resolve ANY import. This will obviously blow up.