### PR TITLE
Changes to support AppContainer ACL on temporary directory/files within

### DIFF
--- a/frida-core.vcxproj
+++ b/frida-core.vcxproj
@@ -87,7 +87,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>G_LOG_DOMAIN=&quot;Frida&quot;;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>G_LOG_DOMAIN="Frida";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)src;$(IntDir)data;$(IntDir)..\frida-pipe-32;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Lib>
@@ -97,7 +97,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>G_LOG_DOMAIN=&quot;Frida&quot;;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>G_LOG_DOMAIN="Frida";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)src;$(IntDir)data;$(IntDir)..\frida-pipe-32;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Lib>
@@ -107,7 +107,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>G_LOG_DOMAIN=&quot;Frida&quot;;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>G_LOG_DOMAIN="Frida";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)src;$(IntDir)data;$(IntDir)..\frida-pipe-64;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Lib>
@@ -117,7 +117,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>G_LOG_DOMAIN=&quot;Frida&quot;;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>G_LOG_DOMAIN="Frida";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)src;$(IntDir)data;$(IntDir)..\frida-pipe-64;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Lib>
@@ -394,6 +394,7 @@ echo &gt; "$(IntDir)valacode.stamp"
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)src\fruity\</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)src\fruity\</ObjectFileName>
     </ClCompile>
+    <ClCompile Include="src\windows\access-helpers.c" />
     <ClCompile Include="src\windows\system-windows.c" />
     <ClCompile Include="src\windows\icon-helpers.c">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)src\</ObjectFileName>
@@ -450,6 +451,7 @@ echo &gt; "$(IntDir)valacode.stamp"
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(IntDir)frida-core.h" />
+    <ClInclude Include="src\windows\access-helpers.h" />
     <ClInclude Include="src\windows\icon-helpers.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/frida-core.vcxproj.filters
+++ b/frida-core.vcxproj.filters
@@ -173,6 +173,9 @@
     <ClCompile Include="src\frida-glue.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\windows\access-helpers.c">
+      <Filter>Source Files\windows</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="src\windows\winjector.resources">
@@ -190,6 +193,9 @@
       <Filter>Header Files\generated</Filter>
     </ClInclude>
     <ClInclude Include="src\windows\icon-helpers.h">
+      <Filter>Source Files\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="src\windows\access-helpers.h">
       <Filter>Source Files\windows</Filter>
     </ClInclude>
   </ItemGroup>

--- a/lib/pipe/frida-pipe-32.vcxproj
+++ b/lib/pipe/frida-pipe-32.vcxproj
@@ -62,6 +62,12 @@
       <UseLibraryDependencyInputs>false</UseLibraryDependencyInputs>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pipe-helpers.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pipe-helpers.h" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/lib/pipe/frida-pipe-32.vcxproj.filters
+++ b/lib/pipe/frida-pipe-32.vcxproj.filters
@@ -27,6 +27,9 @@
     <ClCompile Include="$(IntDir)pipe.c">
       <Filter>Source Files\generated</Filter>
     </ClCompile>
+    <ClCompile Include="pipe-helpers.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="pipe.vala">
@@ -36,6 +39,9 @@
   <ItemGroup>
     <ClInclude Include="$(IntDir)frida-pipe.h">
       <Filter>Header Files\generated</Filter>
+    </ClInclude>
+    <ClInclude Include="pipe-helpers.h">
+      <Filter>Source Files</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/lib/pipe/frida-pipe-64.vcxproj
+++ b/lib/pipe/frida-pipe-64.vcxproj
@@ -62,6 +62,12 @@
       <UseLibraryDependencyInputs>false</UseLibraryDependencyInputs>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pipe-helpers.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pipe-helpers.h" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/lib/pipe/frida-pipe-64.vcxproj.filters
+++ b/lib/pipe/frida-pipe-64.vcxproj.filters
@@ -27,6 +27,9 @@
     <ClCompile Include="$(IntDir)pipe.c">
       <Filter>Source Files\generated</Filter>
     </ClCompile>
+    <ClCompile Include="pipe-helpers.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="pipe.vala">
@@ -36,6 +39,9 @@
   <ItemGroup>
     <ClInclude Include="$(IntDir)frida-pipe.h">
       <Filter>Header Files\generated</Filter>
+    </ClInclude>
+    <ClInclude Include="pipe-helpers.h">
+      <Filter>Source Files</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/lib/pipe/pipe-helpers.c
+++ b/lib/pipe/pipe-helpers.c
@@ -1,0 +1,63 @@
+#include "pipe-helpers.h"
+
+static BOOL frida_pipe_is_windows_vista_or_greater (void);
+static BOOL frida_pipe_is_windows_8_or_greater (void);
+static BOOL frida_pipe_is_windows_version_or_greater (DWORD major, DWORD minor, DWORD service_pack);
+
+LPCWSTR
+frida_pipe_get_sddl_string_for_pipe (void)
+{
+  #define DACL_START_NOINHERIT L"D:PAI"
+  #define DACL_ACE_APPCONTAINER_RW L"(A;;GRGW;;;AC)"
+  #define DACL_ACE_EVERYONE_RW L"(A;;GRGW;;;WD)"
+  #define SACL_START L"S:"
+  #define SACL_ACE_LOWINTEGRITY_NORW L"(ML;;NWNR;;;LW)"
+
+  if (frida_pipe_is_windows_8_or_greater ())
+  {
+    return DACL_START_NOINHERIT DACL_ACE_APPCONTAINER_RW DACL_ACE_EVERYONE_RW SACL_START SACL_ACE_LOWINTEGRITY_NORW;
+  }
+  else if (frida_pipe_is_windows_vista_or_greater ())
+  {
+    return DACL_START_NOINHERIT DACL_ACE_EVERYONE_RW SACL_START SACL_ACE_LOWINTEGRITY_NORW;
+  }
+  else
+  {
+    return DACL_START_NOINHERIT DACL_ACE_EVERYONE_RW;
+  }
+}
+
+static BOOL
+frida_pipe_is_windows_vista_or_greater (void)
+{
+  return frida_pipe_is_windows_version_or_greater (6, 0, 0);
+}
+
+static BOOL
+frida_pipe_is_windows_8_or_greater (void)
+{
+  return frida_pipe_is_windows_version_or_greater (6, 2, 0);
+}
+
+static BOOL
+frida_pipe_is_windows_version_or_greater (DWORD major, DWORD minor, DWORD service_pack)
+{
+  OSVERSIONINFOEXW osvi;
+  ULONGLONG condition_mask;
+
+  ZeroMemory (&osvi, sizeof (osvi));
+  osvi.dwOSVersionInfoSize = sizeof (osvi);
+
+  condition_mask =
+      VerSetConditionMask (
+          VerSetConditionMask (
+              VerSetConditionMask (0, VER_MAJORVERSION, VER_GREATER_EQUAL),
+              VER_MINORVERSION, VER_GREATER_EQUAL),
+          VER_SERVICEPACKMAJOR, VER_GREATER_EQUAL);
+
+  osvi.dwMajorVersion = major;
+  osvi.dwMinorVersion = minor;
+  osvi.wServicePackMajor = service_pack;
+
+  return VerifyVersionInfoW (&osvi, VER_MAJORVERSION | VER_MINORVERSION | VER_SERVICEPACKMAJOR, condition_mask) != FALSE;
+}

--- a/lib/pipe/pipe-helpers.h
+++ b/lib/pipe/pipe-helpers.h
@@ -1,0 +1,10 @@
+#ifndef __FRIDA_WINDOWS_PIPE_HELPERS_H__
+#define __FRIDA_WINDOWS_PIPE_HELPERS_H__
+
+#define VC_EXTRALEAN
+#include <windows.h>
+#undef VC_EXTRALEAN
+
+LPCWSTR frida_pipe_get_sddl_string_for_pipe (void);
+
+#endif

--- a/lib/pipe/pipe-windows.c
+++ b/lib/pipe/pipe-windows.c
@@ -7,8 +7,10 @@
 # pragma warning (pop)
 #endif
 
-#include <windows.h>
+#include "pipe-helpers.h"
+
 #include <sddl.h>
+#include <windows.h>
 
 #define PIPE_BUFSIZE (1024 * 1024)
 
@@ -45,11 +47,6 @@ static WCHAR * frida_pipe_path_from_name (const gchar * name);
 
 static gboolean frida_pipe_backend_await (FridaPipeBackend * self, HANDLE complete, HANDLE cancel, GCancellable * cancellable, GError ** error);
 static void frida_pipe_backend_on_cancel (GCancellable * cancellable, gpointer user_data);
-
-static BOOL frida_pipe_is_windows_version_or_greater (DWORD major, DWORD minor, DWORD service_pack);
-static BOOL frida_pipe_is_windows_8_or_greater (void);
-static BOOL frida_pipe_is_windows_vista_or_greater (void);
-static LPCWSTR frida_pipe_get_sddl_string_for_os (void);
 
 void
 frida_pipe_transport_set_temp_directory (const gchar * path)
@@ -337,7 +334,7 @@ frida_pipe_open (const gchar * name, FridaPipeRole role, GError ** error)
   SECURITY_ATTRIBUTES sa;
 
   path = frida_pipe_path_from_name (name);
-  sddl = frida_pipe_get_sddl_string_for_os ();
+  sddl = frida_pipe_get_sddl_string_for_pipe ();
   success = ConvertStringSecurityDescriptorToSecurityDescriptor (sddl, SDDL_REVISION_1, &sd, NULL);
   CHECK_WINAPI_RESULT (success, !=, FALSE, "ConvertStringSecurityDescriptorToSecurityDescriptor");
 
@@ -420,62 +417,4 @@ frida_pipe_path_from_name (const gchar * name)
   g_free (path_utf8);
 
   return path;
-}
-
-static LPCWSTR
-frida_pipe_get_sddl_string_for_os (void)
-{
-  #define DACL_START_NOINHERIT L"D:PAI"
-  #define DACL_ACE_APPCONTAINER_RW L"(A;;GRGW;;;AC)"
-  #define DACL_ACE_EVERYONE_RW L"(A;;GRGW;;;WD)"
-  #define SACL_START L"S:"
-  #define SACL_ACE_LOWINTEGRITY_NORW L"(ML;;NWNR;;;LW)"
-
-  if (frida_pipe_is_windows_8_or_greater ())
-  {
-    return DACL_START_NOINHERIT DACL_ACE_APPCONTAINER_RW DACL_ACE_EVERYONE_RW SACL_START SACL_ACE_LOWINTEGRITY_NORW;
-  }
-  else if (frida_pipe_is_windows_vista_or_greater ())
-  {
-    return DACL_START_NOINHERIT DACL_ACE_EVERYONE_RW SACL_START SACL_ACE_LOWINTEGRITY_NORW;
-  }
-  else
-  {
-    return DACL_START_NOINHERIT DACL_ACE_EVERYONE_RW;
-  }
-}
-
-static BOOL
-frida_pipe_is_windows_vista_or_greater (void)
-{
-  return frida_pipe_is_windows_version_or_greater (6, 0, 0);
-}
-
-static BOOL
-frida_pipe_is_windows_8_or_greater (void)
-{
-  return frida_pipe_is_windows_version_or_greater (6, 2, 0);
-}
-
-static BOOL
-frida_pipe_is_windows_version_or_greater (DWORD major, DWORD minor, DWORD service_pack)
-{
-  OSVERSIONINFOEXW osvi;
-  ULONGLONG condition_mask;
-
-  ZeroMemory (&osvi, sizeof (osvi));
-  osvi.dwOSVersionInfoSize = sizeof (osvi);
-
-  condition_mask =
-      VerSetConditionMask (
-          VerSetConditionMask (
-              VerSetConditionMask (0, VER_MAJORVERSION, VER_GREATER_EQUAL),
-              VER_MINORVERSION, VER_GREATER_EQUAL),
-          VER_SERVICEPACKMAJOR, VER_GREATER_EQUAL);
-
-  osvi.dwMajorVersion = major;
-  osvi.dwMinorVersion = minor;
-  osvi.wServicePackMajor = service_pack;
-
-  return VerifyVersionInfoW (&osvi, VER_MAJORVERSION | VER_MINORVERSION | VER_SERVICEPACKMAJOR, condition_mask) != FALSE;
 }

--- a/src/windows/access-helpers.c
+++ b/src/windows/access-helpers.c
@@ -1,0 +1,56 @@
+#include "access-helpers.h"
+
+static BOOL frida_access_is_windows_vista_or_greater (void);
+static BOOL frida_access_is_windows_8_or_greater (void);
+static BOOL frida_access_is_windows_version_or_greater (DWORD major, DWORD minor, DWORD service_pack);
+
+LPCWSTR
+frida_access_get_sddl_string_for_temp_directory (void)
+{
+  #define DACL_START_INHERIT L"D:AI"
+  #define DACL_ACE_APPCONTAINER_RW_WITH_CHILD_INHERIT L"(A;OICI;GRGW;;;AC)"
+
+  if (frida_access_is_windows_8_or_greater ())
+  {
+    return DACL_START_INHERIT DACL_ACE_APPCONTAINER_RW_WITH_CHILD_INHERIT;
+  }
+  else
+  {
+    return NULL;
+  }
+}
+
+static BOOL
+frida_access_is_windows_vista_or_greater (void)
+{
+  return frida_access_is_windows_version_or_greater (6, 0, 0);
+}
+
+static BOOL
+frida_access_is_windows_8_or_greater (void)
+{
+  return frida_access_is_windows_version_or_greater (6, 2, 0);
+}
+
+static BOOL
+frida_access_is_windows_version_or_greater (DWORD major, DWORD minor, DWORD service_pack)
+{
+  OSVERSIONINFOEXW osvi;
+  ULONGLONG condition_mask;
+
+  ZeroMemory (&osvi, sizeof (osvi));
+  osvi.dwOSVersionInfoSize = sizeof (osvi);
+
+  condition_mask =
+      VerSetConditionMask (
+          VerSetConditionMask (
+              VerSetConditionMask (0, VER_MAJORVERSION, VER_GREATER_EQUAL),
+              VER_MINORVERSION, VER_GREATER_EQUAL),
+          VER_SERVICEPACKMAJOR, VER_GREATER_EQUAL);
+
+  osvi.dwMajorVersion = major;
+  osvi.dwMinorVersion = minor;
+  osvi.wServicePackMajor = service_pack;
+
+  return VerifyVersionInfoW (&osvi, VER_MAJORVERSION | VER_MINORVERSION | VER_SERVICEPACKMAJOR, condition_mask) != FALSE;
+}

--- a/src/windows/access-helpers.h
+++ b/src/windows/access-helpers.h
@@ -1,0 +1,10 @@
+#ifndef __FRIDA_WINDOWS_ACCESS_HELPERS_H__
+#define __FRIDA_WINDOWS_ACCESS_HELPERS_H__
+
+#define VC_EXTRALEAN
+#include <windows.h>
+#undef VC_EXTRALEAN
+
+LPCWSTR frida_access_get_sddl_string_for_temp_directory (void);
+
+#endif

--- a/src/windows/winjector.vala
+++ b/src/windows/winjector.vala
@@ -267,6 +267,7 @@ namespace Frida {
 
 		public class ResourceStore {
 			private TemporaryDirectory tempdir;
+			private static extern void set_acls_as_needed (string path) throws Error;
 
 			public TemporaryFile helper32 {
 				get;
@@ -283,6 +284,7 @@ namespace Frida {
 
 			public ResourceStore () throws Error {
 				tempdir = new TemporaryDirectory ();
+				set_acls_as_needed (tempdir.path);
 
 				var blob32 = Frida.Data.Winjector.get_winjector_helper_32_exe_blob ();
 				helper32 = new TemporaryFile.from_stream ("frida-winjector-helper-32.exe",


### PR DESCRIPTION
Alters temporary directory ACL, adding AppContainer ACE (with child inheritance for files and folders within) to facilitate Windows Store/Universal app scenarios

There's some minor OS versioning duplication, but this will eventually go away after Windows SDK/VS toolset is updated and VersionHelpers brought in.