### PR TITLE
Prevent libdl from unloading to work around TLS destructor bug

### DIFF
--- a/lib/agent/agent-glue.c
+++ b/lib/agent/agent-glue.c
@@ -55,6 +55,10 @@ static void frida_agent_on_log_message (const gchar * log_domain, GLogLevelFlags
 
 static void frida_agent_auto_ignorer_shutdown (FridaAgentAutoIgnorer * self);
 
+#ifdef HAVE_LINUX
+static void frida_libdl_prevent_unload ();
+#endif
+
 void
 frida_agent_environment_init (void)
 {
@@ -98,7 +102,18 @@ frida_agent_environment_init (void)
   gum_init ();
   gum_script_backend_get_type (); /* Warm up */
   frida_error_quark (); /* Initialize early so GDBus will pick it up */
+#ifdef HAVE_LINUX
+  frida_libdl_prevent_unload ();
+#endif
 }
+
+#ifdef HAVE_LINUX
+void
+frida_libdl_prevent_unload ()
+{
+  __libc_dlopen_mode ("libdl.so.2", RTLD_LAZY | 0x80000000);
+}
+#endif
 
 void
 frida_agent_environment_deinit (FridaAgentAutoIgnorer * ignorer)

--- a/lib/agent/agent-glue.c
+++ b/lib/agent/agent-glue.c
@@ -55,8 +55,10 @@ static void frida_agent_on_log_message (const gchar * log_domain, GLogLevelFlags
 
 static void frida_agent_auto_ignorer_shutdown (FridaAgentAutoIgnorer * self);
 
-#ifdef HAVE_LINUX
-static void frida_libdl_prevent_unload ();
+#if defined (HAVE_LINUX) && !defined (HAVE_ANDROID)
+#define __RTLD_DLOPEN	0x80000000
+extern void * __libc_dlopen_mode (char *name, int flags);
+static void frida_libdl_prevent_unload (void);
 #endif
 
 void
@@ -102,16 +104,16 @@ frida_agent_environment_init (void)
   gum_init ();
   gum_script_backend_get_type (); /* Warm up */
   frida_error_quark (); /* Initialize early so GDBus will pick it up */
-#ifdef HAVE_LINUX
+#if defined (HAVE_LINUX) && !defined (HAVE_ANDROID)
   frida_libdl_prevent_unload ();
 #endif
 }
 
-#ifdef HAVE_LINUX
+#if defined (HAVE_LINUX) && !defined (HAVE_ANDROID)
 void
-frida_libdl_prevent_unload ()
+frida_libdl_prevent_unload (void)
 {
-  __libc_dlopen_mode ("libdl.so.2", RTLD_LAZY | 0x80000000);
+  __libc_dlopen_mode ("libdl.so.2", RTLD_LAZY | __RTLD_DLOPEN);
 }
 #endif
 


### PR DESCRIPTION
Keep a handle to libdl.so.2 so that it is never unloaded even when
libfrida-agent.so unloads in a process that did not previously have
libdl loaded.

This is to prevent a bug which was encountered where libdl tries to
perform a TLS key destructor after the libdl code has been unloaded,
resulting in a segfualt at thread cleanup time.