### PR TITLE
[iOS][FixBug]: app may be killed by watchdog.

### DIFF
--- a/src/darwin/frida-helper-glue.m
+++ b/src/darwin/frida-helper-glue.m
@@ -462,33 +462,30 @@ _frida_helper_service_do_launch (FridaHelperService * self, const gchar * identi
 {
   NSAutoreleasePool * pool;
   FridaSpringboardApi * api;
-  NSDictionary * params, * options;
+  NSString * bundleIDStr = nil;
+  NSURL * urlToOpen = nil;
   UInt32 res;
 
   pool = [[NSAutoreleasePool alloc] init];
 
   api = _frida_get_springboard_api ();
 
-  params = [NSDictionary dictionary];
-
-  options = [NSDictionary dictionaryWithObject:@YES forKey:api->SBSApplicationLaunchOptionUnlockDeviceKey];
+  bundleIDStr = [NSString stringWithUTF8String:identifier];
 
   if (url != NULL)
   {
-    res = api->SBSLaunchApplicationWithIdentifierAndURLAndLaunchOptions (
-        [NSString stringWithUTF8String:identifier],
-        [NSURL URLWithString:[NSString stringWithUTF8String:url]],
-        params,
-        options,
-        NO);
+    urlToOpen = [NSURL URLWithString:[NSString stringWithUTF8String:url]];
   }
-  else
-  {
-    res = api->SBSLaunchApplicationWithIdentifierAndLaunchOptions (
-        [NSString stringWithUTF8String:identifier],
-        options,
-        NO);
-  }
+
+  res = api->SBSLaunchApplicationForDebugging (
+      bundleIDStr,
+      urlToOpen,
+      nil,
+      nil,
+      nil,
+      nil,
+      0x4 // Unlock Device
+    );
 
   if (res != 0)
   {

--- a/src/darwin/springboard.h
+++ b/src/darwin/springboard.h
@@ -20,6 +20,13 @@ struct _FridaSpringboardApi
   NSString * (* SBSApplicationLaunchingErrorString) (UInt32 error);
 
   NSString * SBSApplicationLaunchOptionUnlockDeviceKey;
+
+  /*
+     flags:
+        SBSApplicationLaunchWaitForDebugger = 0x2
+        SBSApplicationLaunchUnlockDevice = 0x4
+  */
+  int (* SBSLaunchApplicationForDebugging) (NSString * bundleID, NSURL * openURL, NSArray * argv, NSDictionary * env, NSString * stdout, NSString * stderr, int flags);
 };
 
 G_GNUC_INTERNAL FridaSpringboardApi * _frida_get_springboard_api (void);

--- a/src/darwin/springboard.m
+++ b/src/darwin/springboard.m
@@ -45,6 +45,9 @@ _frida_get_springboard_api (void)
     g_assert (str != NULL);
     api->SBSApplicationLaunchOptionUnlockDeviceKey = *str;
 
+    api->SBSLaunchApplicationForDebugging = dlsym (api->module, "SBSLaunchApplicationForDebugging");
+    g_assert (api->SBSLaunchApplicationForDebugging != NULL);
+
     frida_springboard_api = api;
   }
 


### PR DESCRIPTION
Issue: app crashed, during "Instrumenting functions..."
Reason: killed by watchdog
Fix: use SBSLaunchApplicationForDebugging to launch app.
Note: my local toolchain is broken, so the code is not tested. please review and test the code first.