### PR TITLE
Handle zombie processes gracefully

### DIFF
--- a/src/qnx/system-qnx.c
+++ b/src/qnx/system-qnx.c
@@ -57,8 +57,9 @@ frida_system_enumerate_processes (int * result_length)
     g_free (tmp);
     g_assert (fd != -1);
 
-    g_assert (devctl (fd, DCMD_PROC_MAPDEBUG_BASE, &procfs_name,
-      sizeof (procfs_name), 0) == EOK);
+    if (devctl (fd, DCMD_PROC_MAPDEBUG_BASE, &procfs_name,
+      sizeof (procfs_name), 0) != EOK)
+	  continue;
 
     name = g_path_get_basename (procfs_name.info.path);
 

--- a/src/qnx/system-qnx.c
+++ b/src/qnx/system-qnx.c
@@ -57,9 +57,8 @@ frida_system_enumerate_processes (int * result_length)
     g_free (tmp);
     g_assert (fd != -1);
 
-    if (devctl (fd, DCMD_PROC_MAPDEBUG_BASE, &procfs_name,
-      sizeof (procfs_name), 0) != EOK)
-	  continue;
+    if (devctl (fd, DCMD_PROC_MAPDEBUG_BASE, &procfs_name, sizeof (procfs_name), 0) != EOK)
+      continue;
 
     name = g_path_get_basename (procfs_name.info.path);
 


### PR DESCRIPTION
These are processes which appear in /proc, but which you cannot open a /proc/<pid>/as for