### PR TITLE
Add support for multiple agent sessions

### DIFF
--- a/lib/agent/agent-container.vala
+++ b/lib/agent/agent-container.vala
@@ -78,6 +78,10 @@ namespace Frida {
 			yield provider.open (id);
 		}
 
+		public async void unload () throws GLib.Error {
+			yield provider.unload ();
+		}
+
 		private void on_session_opened (AgentSessionId id) {
 			opened (id);
 		}

--- a/lib/agent/agent-container.vala
+++ b/lib/agent/agent-container.vala
@@ -1,5 +1,5 @@
 namespace Frida {
-	public class AgentContainer : Object, AgentSession {
+	public class AgentContainer : Object, AgentSessionProvider {
 		private Module module;
 		[CCode (has_target = false)]
 		private delegate void AgentMainFunc (string data_string, Gum.MemoryRange? mapped_range, Gum.ThreadId parent_thread_id);
@@ -7,7 +7,7 @@ namespace Frida {
 		private PipeTransport transport;
 		private Thread<bool> thread;
 		private DBusConnection connection;
-		private AgentSession session;
+		private AgentSessionProvider provider;
 
 		public static async AgentContainer create (string agent_filename) throws Error {
 			var container = new AgentContainer ();
@@ -31,31 +31,24 @@ namespace Frida {
 			container.thread = new Thread<bool> ("frida-agent-container", container.run);
 
 			DBusConnection connection;
-			AgentSession session;
+			AgentSessionProvider provider;
 			try {
 				connection = yield DBusConnection.new (new Pipe (transport.local_address), null, DBusConnectionFlags.NONE);
-				session = yield connection.get_proxy (null, ObjectPath.AGENT_SESSION);
-				session.message_from_script.connect (container.on_message_from_script);
-				session.message_from_debugger.connect (container.on_message_from_debugger);
+				provider = yield connection.get_proxy (null, ObjectPath.AGENT_SESSION_PROVIDER);
+				provider.closed.connect (container.on_session_closed);
 			} catch (GLib.Error dbus_error) {
 				assert_not_reached ();
 			}
 
 			container.connection = connection;
-			container.session = session;
+			container.provider = provider;
 
 			return container;
 		}
 
 		public async void destroy () {
-			session.message_from_script.disconnect (on_message_from_script);
-			session.message_from_debugger.disconnect (on_message_from_debugger);
-
-			try {
-				yield session.close ();
-			} catch (GLib.Error session_error) {
-			}
-			session = null;
+			provider.closed.disconnect (on_session_closed);
+			provider = null;
 
 			try {
 				yield connection.close ();
@@ -75,58 +68,12 @@ namespace Frida {
 			return true;
 		}
 
-		public async void close () throws GLib.Error {
+		public async void open (AgentSessionId id) throws GLib.Error {
+			yield provider.open (id);
 		}
 
-		public async void ping () throws GLib.Error {
-		}
-
-		public async AgentScriptId create_script (string name, string source) throws GLib.Error {
-			return yield session.create_script (name, source);
-		}
-
-		public async AgentScriptId create_script_from_bytes (string name, uint8[] bytes) throws GLib.Error {
-			return yield session.create_script_from_bytes (name, bytes);
-		}
-
-		public async uint8[] compile_script (string source) throws GLib.Error {
-			return yield session.compile_script (source);
-		}
-
-		public async void destroy_script (AgentScriptId sid) throws GLib.Error {
-			yield session.destroy_script (sid);
-		}
-
-		public async void load_script (AgentScriptId sid) throws GLib.Error {
-			yield session.load_script (sid);
-		}
-
-		public async void post_message_to_script (AgentScriptId sid, string message) throws GLib.Error {
-			yield session.post_message_to_script (sid, message);
-		}
-
-		public async void enable_debugger () throws GLib.Error {
-			yield session.enable_debugger ();
-		}
-
-		public async void disable_debugger () throws GLib.Error {
-			yield session.disable_debugger ();
-		}
-
-		public async void post_message_to_debugger (string message) throws GLib.Error {
-			yield session.post_message_to_debugger (message);
-		}
-
-		public async void disable_jit () throws GLib.Error {
-			yield session.disable_jit ();
-		}
-
-		private void on_message_from_script (AgentScriptId sid, string message, uint8[] data) {
-			message_from_script (sid, message, data);
-		}
-
-		private void on_message_from_debugger (string message) {
-			message_from_debugger (message);
+		private void on_session_closed (AgentSessionId id) {
+			closed (id);
 		}
 	}
 }

--- a/lib/agent/agent.vala
+++ b/lib/agent/agent.vala
@@ -64,6 +64,8 @@ namespace Frida.Agent {
 			} catch (IOError io_error) {
 				assert_not_reached ();
 			}
+
+			opened (id);
 		}
 
 		private void on_client_closed (AgentClient client) {

--- a/lib/agent/script-engine.vala
+++ b/lib/agent/script-engine.vala
@@ -9,6 +9,7 @@ namespace Frida.Agent {
 		private Gum.MemoryRange agent_range;
 		private uint last_script_id = 0;
 		private HashMap<uint, ScriptInstance> instance_by_id = new HashMap<uint, ScriptInstance> ();
+		private bool debugger_enabled = false;
 
 		public ScriptEngine (Gum.ScriptBackend backend, Gum.MemoryRange agent_range) {
 			this.backend = backend;
@@ -20,6 +21,11 @@ namespace Frida.Agent {
 				yield instance.destroy ();
 			}
 			instance_by_id.clear ();
+
+			if (debugger_enabled) {
+				backend.set_debug_message_handler (null);
+				debugger_enabled = false;
+			}
 		}
 
 		public async ScriptInstance create_script (string? name, string? source, Bytes? bytes) throws Error {
@@ -83,10 +89,12 @@ namespace Frida.Agent {
 
 		public void enable_debugger () throws Error {
 			backend.set_debug_message_handler (on_debug_message);
+			debugger_enabled = true;
 		}
 
 		public void disable_debugger () throws Error {
 			backend.set_debug_message_handler (null);
+			debugger_enabled = false;
 		}
 
 		public void post_message_to_debugger (string message) {

--- a/lib/gadget/script-engine.vala
+++ b/lib/gadget/script-engine.vala
@@ -9,6 +9,7 @@ namespace Frida.Gadget {
 		private Gum.MemoryRange agent_range;
 		private uint last_script_id = 0;
 		private HashMap<uint, ScriptInstance> instance_by_id = new HashMap<uint, ScriptInstance> ();
+		private bool debugger_enabled = false;
 
 		public ScriptEngine (Gum.ScriptBackend backend, Gum.MemoryRange agent_range) {
 			this.backend = backend;
@@ -20,6 +21,11 @@ namespace Frida.Gadget {
 				yield instance.destroy ();
 			}
 			instance_by_id.clear ();
+
+			if (debugger_enabled) {
+				backend.set_debug_message_handler (null);
+				debugger_enabled = false;
+			}
 		}
 
 		public async ScriptInstance create_script (string? name, string? source, Bytes? bytes) throws Error {
@@ -83,10 +89,12 @@ namespace Frida.Gadget {
 
 		public void enable_debugger () throws Error {
 			backend.set_debug_message_handler (on_debug_message);
+			debugger_enabled = true;
 		}
 
 		public void disable_debugger () throws Error {
 			backend.set_debug_message_handler (null);
+			debugger_enabled = false;
 		}
 
 		public void post_message_to_debugger (string message) {

--- a/lib/interfaces/session.vala
+++ b/lib/interfaces/session.vala
@@ -1,5 +1,5 @@
 namespace Frida {
-	[DBus (name = "re.frida.HostSession7")]
+	[DBus (name = "re.frida.HostSession8")]
 	public interface HostSession : Object {
 		public abstract async HostApplicationInfo get_frontmost_application () throws GLib.Error;
 		public abstract async HostApplicationInfo[] enumerate_applications () throws GLib.Error;
@@ -19,11 +19,16 @@ namespace Frida {
 		public signal void agent_session_destroyed (AgentSessionId id);
 	}
 
-	[DBus (name = "re.frida.AgentSession7")]
+	[DBus (name = "re.frida.AgentSessionProvider8")]
+	public interface AgentSessionProvider : Object {
+		public abstract async void open (AgentSessionId id) throws GLib.Error;
+
+		public signal void closed (AgentSessionId id);
+	}
+
+	[DBus (name = "re.frida.AgentSession8")]
 	public interface AgentSession : Object {
 		public abstract async void close () throws GLib.Error;
-
-		public abstract async void ping () throws GLib.Error;
 
 		public abstract async AgentScriptId create_script (string name, string source) throws GLib.Error;
 		public abstract async AgentScriptId create_script_from_bytes (string name, uint8[] bytes) throws GLib.Error;
@@ -206,6 +211,7 @@ namespace Frida {
 
 	namespace ObjectPath {
 		public const string HOST_SESSION = "/re/frida/HostSession";
+		public const string AGENT_SESSION_PROVIDER = "/re/frida/AgentSessionProvider";
 		public const string AGENT_SESSION = "/re/frida/AgentSession";
 
 		public static string from_agent_session_id (AgentSessionId id) {

--- a/lib/interfaces/session.vala
+++ b/lib/interfaces/session.vala
@@ -22,6 +22,7 @@ namespace Frida {
 	[DBus (name = "re.frida.AgentSessionProvider8")]
 	public interface AgentSessionProvider : Object {
 		public abstract async void open (AgentSessionId id) throws GLib.Error;
+		public abstract async void unload () throws GLib.Error;
 
 		public signal void opened (AgentSessionId id);
 		public signal void closed (AgentSessionId id);

--- a/lib/interfaces/session.vala
+++ b/lib/interfaces/session.vala
@@ -23,6 +23,7 @@ namespace Frida {
 	public interface AgentSessionProvider : Object {
 		public abstract async void open (AgentSessionId id) throws GLib.Error;
 
+		public signal void opened (AgentSessionId id);
 		public signal void closed (AgentSessionId id);
 	}
 

--- a/src/darwin/darwin-host-session.vala
+++ b/src/darwin/darwin-host-session.vala
@@ -123,7 +123,7 @@ namespace Frida {
 			helper = null;
 		}
 
-		protected override async AgentSession create_system_session () throws Error {
+		protected override async AgentSessionProvider create_system_session () throws Error {
 			return yield helper.create_system_session (agent.file.path);
 		}
 

--- a/src/darwin/darwin-host-session.vala
+++ b/src/darwin/darwin-host-session.vala
@@ -89,7 +89,6 @@ namespace Frida {
 
 		construct {
 			helper = new HelperProcess ();
-			helper.stopped.connect (on_helper_stopped);
 			helper.output.connect (on_output);
 			injector = new Fruitjector.with_helper (helper);
 
@@ -119,12 +118,11 @@ namespace Frida {
 
 			yield helper.close ();
 			helper.output.disconnect (on_output);
-			helper.stopped.disconnect (on_helper_stopped);
 			helper = null;
 		}
 
-		protected override async AgentSessionProvider create_system_session () throws Error {
-			return yield helper.create_system_session (agent.file.path);
+		protected override async AgentSessionProvider create_system_session_provider (out DBusConnection connection) throws Error {
+			return yield helper.create_system_session_provider (agent.file.path, out connection);
 		}
 
 		public override async HostApplicationInfo get_frontmost_application () throws Error {
@@ -219,10 +217,6 @@ namespace Frida {
 				fruit_launcher.spawned.connect ((info) => { spawned (info); });
 			}
 			return fruit_launcher;
-		}
-
-		private void on_helper_stopped () {
-			release_system_session ();
 		}
 
 		private void on_output (uint pid, int fd, uint8[] data) {

--- a/src/darwin/frida-helper-process.vala
+++ b/src/darwin/frida-helper-process.vala
@@ -57,7 +57,7 @@ namespace Frida {
 			yield obtain ();
 		}
 
-		public async AgentSession create_system_session (string agent_filename) throws Error {
+		public async AgentSessionProvider create_system_session (string agent_filename) throws Error {
 			var helper = yield obtain ();
 			try {
 				var system_session_path = yield helper.create_system_session (agent_filename);

--- a/src/darwin/frida-helper-process.vala
+++ b/src/darwin/frida-helper-process.vala
@@ -60,7 +60,7 @@ namespace Frida {
 			var helper = yield obtain ();
 			try {
 				var provider_path = yield helper.create_system_session_provider (agent_filename);
-				var provider = yield connection.get_proxy (null, provider_path);
+				AgentSessionProvider provider = yield connection.get_proxy (null, provider_path);
 				conn = connection;
 				return provider;
 			} catch (GLib.Error e) {

--- a/src/darwin/frida-helper-process.vala
+++ b/src/darwin/frida-helper-process.vala
@@ -1,7 +1,6 @@
 #if DARWIN
 namespace Frida {
 	internal class HelperProcess {
-		public signal void stopped ();
 		public signal void output (uint pid, int fd, uint8[] data);
 		public signal void uninjected (uint id);
 
@@ -57,11 +56,13 @@ namespace Frida {
 			yield obtain ();
 		}
 
-		public async AgentSessionProvider create_system_session (string agent_filename) throws Error {
+		public async AgentSessionProvider create_system_session_provider (string agent_filename, out DBusConnection conn) throws Error {
 			var helper = yield obtain ();
 			try {
-				var system_session_path = yield helper.create_system_session (agent_filename);
-				return yield connection.get_proxy (null, system_session_path);
+				var provider_path = yield helper.create_system_session_provider (agent_filename);
+				var provider = yield connection.get_proxy (null, provider_path);
+				conn = connection;
+				return provider;
 			} catch (GLib.Error e) {
 				throw Marshal.from_dbus (e);
 			}
@@ -239,8 +240,6 @@ namespace Frida {
 			connection = null;
 
 			process = null;
-
-			stopped ();
 		}
 
 		private void on_output (uint pid, int fd, uint8[] data) {

--- a/src/darwin/frida-helper-types.vala
+++ b/src/darwin/frida-helper-types.vala
@@ -4,7 +4,7 @@ namespace Frida {
 	public interface Helper : Object {
 		public signal void uninjected (uint id);
 		public abstract async void stop () throws GLib.Error;
-		public abstract async string create_system_session (string agent_filename) throws GLib.Error;
+		public abstract async string create_system_session_provider (string agent_filename) throws GLib.Error;
 		public abstract async uint spawn (string path, string[] argv, string[] envp) throws GLib.Error;
 		public abstract async void launch (string identifier, string url) throws GLib.Error;
 		public abstract async void input (uint pid, uint8[] data) throws GLib.Error;

--- a/src/darwin/frida-helper-types.vala
+++ b/src/darwin/frida-helper-types.vala
@@ -43,7 +43,7 @@ namespace Frida {
 
 	namespace ObjectPath {
 		public const string HELPER = "/re/frida/Helper";
-		public const string SYSTEM_SESSION = "/re/frida/SystemSession";
+		public const string SYSTEM_SESSION_PROVIDER = "/re/frida/SystemSessionProvider";
 		public const string TUNNELED_STREAM = "/re/frida/TunneledStream";
 
 		public static string from_tunneled_stream_id (uint id) {

--- a/src/darwin/frida-helper.vala
+++ b/src/darwin/frida-helper.vala
@@ -140,10 +140,10 @@ namespace Frida {
 			assert (system_session == null);
 
 			system_session = yield AgentContainer.create (agent_filename);
-			AgentSession system_agent_session = system_session;
-			system_session_registration_id = connection.register_object (Frida.ObjectPath.SYSTEM_SESSION, system_agent_session);
+			AgentSessionProvider system_session_provider = system_session;
+			system_session_registration_id = connection.register_object (Frida.ObjectPath.SYSTEM_SESSION_PROVIDER, system_session_provider);
 
-			return Frida.ObjectPath.SYSTEM_SESSION;
+			return Frida.ObjectPath.SYSTEM_SESSION_PROVIDER;
 		}
 
 		public async uint spawn (string path, string[] argv, string[] envp) throws Error {

--- a/src/darwin/frida-helper.vala
+++ b/src/darwin/frida-helper.vala
@@ -39,7 +39,8 @@ namespace Frida {
 		private DBusConnection connection;
 		private uint helper_registration_id = 0;
 		private uint system_session_registration_id = 0;
-		private AgentContainer system_session;
+		private AgentContainer system_session_container;
+		private Gee.HashMap<uint, uint> system_sessions = new Gee.HashMap<uint, uint> ();
 		private Gee.HashMap<uint, OutputStream> stdin_streams = new Gee.HashMap<uint, OutputStream> ();
 		private Gee.HashMap<PipeProxy, uint> pipe_proxies = new Gee.HashMap<PipeProxy, uint> ();
 		private uint last_pipe_proxy_id = 1;
@@ -86,15 +87,23 @@ namespace Frida {
 			shutdown_request = new Gee.Promise<bool> ();
 
 			if (connection != null) {
+				foreach (var registration_id in system_sessions.values)
+					connection.unregister_object (registration_id);
+				system_sessions.clear ();
+
 				foreach (var registration_id in pipe_proxies.values)
 					connection.unregister_object (registration_id);
 				pipe_proxies.clear ();
 
-				if (system_session != null) {
+				if (system_session_container != null) {
+					system_session_container.opened.disconnect (on_system_session_opened);
+					system_session_container.closed.disconnect (on_system_session_closed);
+
 					assert (system_session_registration_id != 0);
 					connection.unregister_object (system_session_registration_id);
-					yield system_session.destroy ();
-					system_session = null;
+
+					yield system_session_container.destroy ();
+					system_session_container = null;
 				}
 
 				if (helper_registration_id != 0)
@@ -136,14 +145,34 @@ namespace Frida {
 			});
 		}
 
-		public async string create_system_session (string agent_filename) throws GLib.Error {
-			assert (system_session == null);
+		public async string create_system_session_provider (string agent_filename) throws GLib.Error {
+			assert (system_session_container == null);
 
-			system_session = yield AgentContainer.create (agent_filename);
-			AgentSessionProvider system_session_provider = system_session;
-			system_session_registration_id = connection.register_object (Frida.ObjectPath.SYSTEM_SESSION_PROVIDER, system_session_provider);
+			system_session_container = yield AgentContainer.create (agent_filename);
+			AgentSessionProvider provider = system_session_container;
+			system_session_registration_id = connection.register_object (Frida.ObjectPath.SYSTEM_SESSION_PROVIDER, provider);
+
+			provider.opened.connect (on_system_session_opened);
+			provider.closed.connect (on_system_session_closed);
 
 			return Frida.ObjectPath.SYSTEM_SESSION_PROVIDER;
+		}
+
+		private void on_system_session_opened (AgentSessionId id) {
+			try {
+				var session_path = ObjectPath.from_agent_session_id (id);
+				AgentSession session = system_session_container.connection.get_proxy_sync (null, session_path);
+				var session_registration = connection.register_object (session_path, session);
+				system_sessions[id.handle] = session_registration;
+			} catch (GLib.Error e) {
+			}
+		}
+
+		private void on_system_session_closed (AgentSessionId id) {
+			uint session_registration;
+			var found = system_sessions.unset (id.handle, out session_registration);
+			assert (found);
+			connection.unregister_object (session_registration);
 		}
 
 		public async uint spawn (string path, string[] argv, string[] envp) throws Error {

--- a/src/host-session-service.vala
+++ b/src/host-session-service.vala
@@ -135,35 +135,36 @@ namespace Frida {
 		public signal void agent_session_opened (AgentSessionId id, AgentSession session);
 		public signal void agent_session_closed (AgentSessionId id, AgentSession session);
 
-		private Gee.ArrayList<Entry> entries = new Gee.ArrayList<Entry> ();
-		private Gee.HashMap<uint, Gee.Promise<uint>> pending_attach_requests = new Gee.HashMap<uint, Gee.Promise<uint>> ();
-		private uint last_session_id = 0;
+		private Gee.HashMap<uint, Gee.Promise<Entry>> entries = new Gee.HashMap<uint, Gee.Promise<Entry>> ();
+		private Gee.HashMap<uint, AgentSession> sessions = new Gee.HashMap<uint, AgentSession> ();
+		private uint next_session_id = 1;
 
 		public virtual async void close () {
-			while (!pending_attach_requests.is_empty) {
-				var iterator = pending_attach_requests.values.iterator ();
+			while (!entries.is_empty) {
+				var iterator = entries.values.iterator ();
 				iterator.next ();
-				var attach_request = iterator.get ();
+				var request = iterator.get ();
 				try {
-					yield attach_request.future.wait_async ();
+					var entry = yield request.future.wait_async ();
+					entries.unset (entry.pid);
+					yield entry.close ();
 				} catch (Gee.FutureError e) {
 				}
 			}
-
-			foreach (var entry in entries.slice (0, entries.size))
-				yield entry.close ();
-			entries.clear ();
 		}
 
-		protected abstract async AgentSession create_system_session () throws Error;
+		protected abstract async AgentSessionProvider create_system_session () throws Error;
 
 		protected void release_system_session () {
-			foreach (var entry in entries) {
-				if (entry.pid == 0) {
-					destroy (entry);
-					return;
-				}
-			}
+			var promise = entries[0];
+			if (promise == null)
+				return;
+
+			var future = promise.future;
+			if (!future.ready)
+				return;
+
+			destroy (future.value);
 		}
 
 		public abstract async HostApplicationInfo get_frontmost_application () throws Error;
@@ -187,33 +188,48 @@ namespace Frida {
 		public abstract async void kill (uint pid) throws Error;
 
 		public async Frida.AgentSessionId attach_to (uint pid) throws Error {
-			foreach (var e in entries) {
-				if (e.pid == pid)
-					return e.id;
+			var entry = yield establish (pid);
+
+			var id = AgentSessionId (next_session_id++);
+			var raw_id = id.handle;
+			AgentSession session;
+
+			try {
+				yield entry.provider.open (id);
+
+				session = yield entry.connection.get_proxy (null, ObjectPath.from_agent_session_id (id), DBusProxyFlags.NONE, null);
+			} catch (GLib.Error e) {
+				throw new Error.PROTOCOL (e.message);
 			}
 
-			var attach_request = pending_attach_requests[pid];
-			if (attach_request != null) {
-				var future = attach_request.future;
+			sessions[raw_id] = session;
+			entry.sessions.add (raw_id);
+
+			agent_session_opened (id, session);
+
+			return id;
+		}
+
+		private async Entry establish (uint pid) throws Error {
+			var promise = entries[pid];
+			if (promise != null) {
+				var future = promise.future;
 				try {
-					var handle = yield future.wait_async ();
-					return AgentSessionId (handle);
+					return yield future.wait_async ();
 				} catch (Gee.FutureError e) {
 					throw (Error) future.exception;
 				}
 			}
-			attach_request = new Gee.Promise<uint> ();
-			pending_attach_requests[pid] = attach_request;
+			promise = new Gee.Promise<Entry> ();
+			entries[pid] = promise;
 
-			AgentSessionId id;
+			Entry entry;
 			try {
-				AgentSession session;
-				Entry entry;
+				AgentSessionProvider provider;
 
 				if (pid == 0) {
-					id = Frida.AgentSessionId (0);
-					session = yield create_system_session ();
-					entry = new Entry (id, pid, null, null, session);
+					provider = yield create_system_session ();
+					entry = new Entry (pid, null, null, provider);
 				} else {
 					Object transport;
 					var stream = yield perform_attach_to (pid, out transport);
@@ -229,7 +245,7 @@ namespace Frida {
 					DBusConnection connection;
 					try {
 						connection = yield DBusConnection.new (stream, null, DBusConnectionFlags.NONE, null, cancellable);
-						session = yield connection.get_proxy (null, ObjectPath.AGENT_SESSION, DBusProxyFlags.NONE, cancellable);
+						provider = yield connection.get_proxy (null, ObjectPath.AGENT_SESSION_PROVIDER, DBusProxyFlags.NONE, cancellable);
 					} catch (GLib.Error establish_error) {
 						if (establish_error is IOError.CANCELLED)
 							throw new Error.PROCESS_NOT_RESPONDING ("Timed out while waiting for session to establish");
@@ -241,34 +257,29 @@ namespace Frida {
 
 					timeout_source.destroy ();
 
-					id = AgentSessionId (++last_session_id);
-
-					entry = new Entry (id, pid, transport, connection, session);
+					entry = new Entry (pid, transport, connection, provider);
 					connection.closed.connect (on_connection_closed);
+					provider.closed.connect (on_session_closed);
 				}
-				entries.add (entry);
 
-				agent_session_opened (id, session);
-
-				attach_request.set_value (id.handle);
-				pending_attach_requests.unset (pid);
+				promise.set_value (entry);
 			} catch (Error e) {
-				attach_request.set_exception (e);
-				pending_attach_requests.unset (pid);
+				entries.unset (pid);
+
+				promise.set_exception (e);
 				throw e;
 			}
 
-			return id;
+			return entry;
 		}
 
 		protected abstract async IOStream perform_attach_to (uint pid, out Object? transport) throws Error;
 
 		public async AgentSession obtain_agent_session (AgentSessionId id) throws Error {
-			foreach (var entry in entries) {
-				if (entry.id.handle == id.handle)
-					return entry.agent_session;
-			}
-			throw new Error.INVALID_ARGUMENT ("Invalid session ID");
+			var session = sessions[id.handle];
+			if (session == null)
+				throw new Error.INVALID_ARGUMENT ("Invalid session ID");
+			return session;
 		}
 
 		private void on_connection_closed (DBusConnection connection, bool remote_peer_vanished, GLib.Error? error) {
@@ -277,8 +288,14 @@ namespace Frida {
 				return;
 
 			Entry entry_to_remove = null;
-			foreach (var entry in entries) {
-				if (entry.agent_connection == connection) {
+			foreach (var promise in entries.values) {
+				var future = promise.future;
+
+				if (!future.ready)
+					continue;
+
+				var entry = future.value;
+				if (entry.connection == connection) {
 					entry_to_remove = entry;
 					break;
 				}
@@ -288,23 +305,47 @@ namespace Frida {
 			destroy (entry_to_remove);
 		}
 
-		private void destroy (Entry entry) {
-			var id = entry.id;
+		private void on_session_closed (AgentSessionId id) {
+			var raw_id = id.handle;
 
-			entries.remove (entry);
+			AgentSession session;
+			var found = sessions.unset (raw_id, out session);
+			assert (found);
+			agent_session_closed (id, session);
+			agent_session_destroyed (id);
+
+			foreach (var promise in entries.values) {
+				var future = promise.future;
+
+				if (!future.ready)
+					continue;
+
+				var entry = future.value;
+				entry.sessions.remove (raw_id);
+			}
+		}
+
+		private void destroy (Entry entry) {
+			entry.provider.closed.disconnect (on_session_closed);
+			entry.connection.closed.disconnect (on_connection_closed);
+
+			entries.unset (entry.pid);
 
 			entry.close.begin ();
-			agent_session_closed (id, entry.agent_session);
 
-			agent_session_destroyed (id);
+			foreach (var raw_id in entry.sessions) {
+				var id = AgentSessionId (raw_id);
+
+				AgentSession session;
+				var found = sessions.unset (raw_id, out session);
+				assert (found);
+
+				agent_session_closed (id, session);
+				agent_session_destroyed (id);
+			}
 		}
 
 		private class Entry : Object {
-			public AgentSessionId id {
-				get;
-				construct;
-			}
-
 			public uint pid {
 				get;
 				construct;
@@ -315,20 +356,31 @@ namespace Frida {
 				construct;
 			}
 
-			public DBusConnection? agent_connection {
+			public DBusConnection? connection {
 				get;
 				construct;
 			}
 
-			public AgentSession agent_session {
+			public AgentSessionProvider provider {
+				get;
+				construct;
+			}
+
+			public Gee.HashSet<uint> sessions {
 				get;
 				construct;
 			}
 
 			private Gee.Promise<bool> close_request;
 
-			public Entry (AgentSessionId id, uint pid, Object? transport, DBusConnection? agent_connection, AgentSession agent_session) {
-				Object (id: id, pid: pid, transport: transport, agent_connection: agent_connection, agent_session: agent_session);
+			public Entry (uint pid, Object? transport, DBusConnection? connection, AgentSessionProvider provider) {
+				Object (
+					pid: pid,
+					transport: transport,
+					connection: connection,
+					provider: provider,
+					sessions: new Gee.HashSet<uint> ()
+				);
 			}
 
 			public async void close () {
@@ -342,10 +394,10 @@ namespace Frida {
 				}
 				close_request = new Gee.Promise<bool> ();
 
-				if (agent_connection != null) {
+				if (connection != null) {
 					try {
-						yield agent_connection.close ();
-					} catch (GLib.Error agent_conn_error) {
+						yield connection.close ();
+					} catch (GLib.Error e) {
 					}
 				}
 

--- a/src/host-session-service.vala
+++ b/src/host-session-service.vala
@@ -337,7 +337,14 @@ namespace Frida {
 					continue;
 
 				var entry = future.value;
-				entry.sessions.remove (raw_id);
+
+				var sessions = entry.sessions;
+				sessions.remove (raw_id);
+				if (sessions.is_empty) {
+					var is_system_session = entry.pid == 0;
+					if (!is_system_session)
+						entry.provider.unload.begin ();
+				}
 			}
 		}
 

--- a/src/linux/linux-host-session.vala
+++ b/src/linux/linux-host-session.vala
@@ -71,7 +71,7 @@ namespace Frida {
 	}
 
 	public class LinuxHostSession : BaseDBusHostSession {
-		private AgentContainer system_session = null;
+		private AgentContainer system_session_container;
 
 		private HelperProcess helper;
 		private Linjector injector;
@@ -124,16 +124,17 @@ namespace Frida {
 			helper.output.disconnect (on_output);
 			helper = null;
 
-			if (system_session != null) {
-				yield system_session.destroy ();
-				system_session = null;
+			if (system_session_container != null) {
+				yield system_session_container.destroy ();
+				system_session_container = null;
 			}
 		}
 
-		protected override async AgentSession create_system_session () throws Error {
+		protected override async AgentSessionProvider create_system_session_provider (out DBusConnection connection) throws Error {
 			var agent_filename = agent.path_template.printf (sizeof (void *) == 8 ? 64 : 32);
-			system_session = yield AgentContainer.create (agent_filename);
-			return system_session;
+			system_session_container = yield AgentContainer.create (agent_filename);
+			connection = system_session_container.connection;
+			return system_session_container;
 		}
 
 		public override async HostApplicationInfo get_frontmost_application () throws Error {

--- a/src/qnx/qnx-host-session.vala
+++ b/src/qnx/qnx-host-session.vala
@@ -71,7 +71,7 @@ namespace Frida {
 	}
 
 	public class QnxHostSession : BaseDBusHostSession {
-		private AgentContainer system_session = null;
+		private AgentContainer system_session_container;
 
 		public Gee.HashMap<uint, void *> instance_by_pid = new Gee.HashMap<uint, void *> ();
 
@@ -92,16 +92,17 @@ namespace Frida {
 			injector.disconnect (uninjected_handler);
 			injector = null;
 
-			if (system_session != null) {
-				yield system_session.destroy ();
-				system_session = null;
+			if (system_session_container != null) {
+				yield system_session_container.destroy ();
+				system_session_container = null;
 			}
 		}
 
-		protected override async AgentSession create_system_session () throws Error {
+		protected override async AgentSessionProvider create_system_session_provider (out DBusConnection connection) throws Error {
 			var agent_filename = injector.resource_store.ensure_copy_of (agent_desc);
-			system_session = yield AgentContainer.create (agent_filename);
-			return system_session;
+			system_session_container = yield AgentContainer.create (agent_filename);
+			connection = system_session_container.connection;
+			return system_session_container;
 		}
 
 		public override async HostApplicationInfo get_frontmost_application () throws Error {

--- a/src/windows/windows-host-session.vala
+++ b/src/windows/windows-host-session.vala
@@ -81,7 +81,7 @@ namespace Frida {
 	}
 
 	public class WindowsHostSession : BaseDBusHostSession {
-		private AgentContainer system_session = null;
+		private AgentContainer system_session_container = null;
 
 		private Gee.HashMap<uint, ChildProcess> processes = new Gee.HashMap<uint, ChildProcess> ();
 
@@ -123,9 +123,9 @@ namespace Frida {
 			yield winjector.close ();
 			winjector = null;
 
-			if (system_session != null) {
-				yield system_session.destroy ();
-				system_session = null;
+			if (system_session_container != null) {
+				yield system_session_container.destroy ();
+				system_session_container = null;
 			}
 
 			foreach (var process in processes.values)
@@ -133,11 +133,12 @@ namespace Frida {
 			processes.clear ();
 		}
 
-		protected override async AgentSession create_system_session () throws Error {
+		protected override async AgentSessionProvider create_system_session_provider (out DBusConnection connection) throws Error {
 			var path_template = winjector.normal_resource_store.ensure_copy_of (agent_desc);
 			var agent_filename = path_template.printf (sizeof (void *) == 8 ? 64 : 32);
-			system_session = yield AgentContainer.create (agent_filename);
-			return system_session;
+			system_session_container = yield AgentContainer.create (agent_filename);
+			connection = system_session_container.connection;
+			return system_session_container;
 		}
 
 		public override async HostApplicationInfo get_frontmost_application () throws Error {

--- a/src/windows/windows-host-session.vala
+++ b/src/windows/windows-host-session.vala
@@ -81,7 +81,7 @@ namespace Frida {
 	}
 
 	public class WindowsHostSession : BaseDBusHostSession {
-		private AgentContainer system_session_container = null;
+		private AgentContainer system_session_container;
 
 		private Gee.HashMap<uint, ChildProcess> processes = new Gee.HashMap<uint, ChildProcess> ();
 


### PR DESCRIPTION
This addresses a long-standing design flaw where each `attach()` request would return the same object, or more precisely, the same shared session. The result was that clients would need to coordinate so that two clients interested in attaching to the same process wouldn't step on each other in case one decided to `detach()` once it was done.