### PR TITLE
Avoid racing on agent thread creation / monitoring

### DIFF
--- a/src/darwin/frida-helper-backend-glue.m
+++ b/src/darwin/frida-helper-backend-glue.m
@@ -1247,10 +1247,10 @@ _frida_darwin_helper_backend_inject_into_task (FridaDarwinHelperBackend * self, 
   }
 #endif
 
-  ret = thread_create(task, &instance->thread);
+  ret = thread_create (task, &instance->thread);
   CHECK_MACH_RESULT (ret, ==, KERN_SUCCESS, "thread_create");
 
-  ret = act_set_state(instance->thread, state_flavor, state_data, state_count);
+  ret = act_set_state (instance->thread, state_flavor, state_data, state_count);
   CHECK_MACH_RESULT (ret, ==, KERN_SUCCESS, "act_set_state");
 
   gee_abstract_map_set (GEE_ABSTRACT_MAP (self->inject_instance_by_id), GUINT_TO_POINTER (instance->id), instance);
@@ -1262,7 +1262,7 @@ _frida_darwin_helper_backend_inject_into_task (FridaDarwinHelperBackend * self, 
   dispatch_source_set_event_handler_f (source, frida_inject_instance_on_mach_thread_dead);
   dispatch_resume (source);
 
-  ret = thread_resume(instance->thread);
+  ret = thread_resume (instance->thread);
   CHECK_MACH_RESULT (ret, ==, KERN_SUCCESS, "thread_resume");
 
   result = instance->id;

--- a/src/darwin/frida-helper-backend-glue.m
+++ b/src/darwin/frida-helper-backend-glue.m
@@ -1247,8 +1247,11 @@ _frida_darwin_helper_backend_inject_into_task (FridaDarwinHelperBackend * self, 
   }
 #endif
 
-  ret = thread_create_running (task, state_flavor, state_data, state_count, &instance->thread);
-  CHECK_MACH_RESULT (ret, ==, KERN_SUCCESS, "thread_create_running");
+  ret = thread_create(task, &instance->thread);
+  CHECK_MACH_RESULT (ret, ==, KERN_SUCCESS, "thread_create");
+
+  ret = act_set_state(instance->thread, state_flavor, state_data, state_count);
+  CHECK_MACH_RESULT (ret, ==, KERN_SUCCESS, "act_set_state");
 
   gee_abstract_map_set (GEE_ABSTRACT_MAP (self->inject_instance_by_id), GUINT_TO_POINTER (instance->id), instance);
 
@@ -1258,6 +1261,9 @@ _frida_darwin_helper_backend_inject_into_task (FridaDarwinHelperBackend * self, 
   dispatch_set_context (source, instance);
   dispatch_source_set_event_handler_f (source, frida_inject_instance_on_mach_thread_dead);
   dispatch_resume (source);
+
+  ret = thread_resume(instance->thread);
+  CHECK_MACH_RESULT (ret, ==, KERN_SUCCESS, "thread_resume");
 
   result = instance->id;
   goto beach;


### PR DESCRIPTION
Resuming the newly created thread only after dispatch_resume greatly decreases the
probability to miss the DISPATCH_MACH_SEND_DEAD event.