### PR TITLE
On MacOS, create a hidden subdirectory to use for tmp

### DIFF
--- a/src/darwin/system-darwin.m
+++ b/src/darwin/system-darwin.m
@@ -304,7 +304,7 @@ frida_temporary_directory_get_system_tmp (void)
   {
 #ifdef HAVE_MACOS
     /* Mac App Store apps are sandboxed but able to read ~/.Trash/ */
-    return g_build_filename (g_get_home_dir (), ".Trash", NULL);
+    return g_build_filename (g_get_home_dir (), ".Trash", ".frida", NULL);
 #else
     return g_strdup (g_get_tmp_dir ());
 #endif

--- a/src/system.vala
+++ b/src/system.vala
@@ -129,7 +129,7 @@ namespace Frida {
 					file = File.new_for_path (Path.build_filename (get_system_tmp (), name));
 
 					try {
-						file.make_directory ();
+						file.make_directory_with_parents ();
 					} catch (GLib.Error e) {
 						// Following operations will fail
 					}


### PR DESCRIPTION
This way the trash icon can remain empty, so you don't want to always empty it.