### PR TITLE
Trick to load .config.so file in ANDROID instead of .config

### DIFF
--- a/lib/gadget/gadget.vala
+++ b/lib/gadget/gadget.vala
@@ -499,8 +499,7 @@ namespace Frida.Gadget {
 			var ext_index = config_path.last_index_of_char ('.');
 			if (ext_index != -1) {
 				config_path = config_path[0:ext_index] + ".config.so";
-			}
-			else{
+			} else{
 				config_path = config_path + ".config.so";
 			}
 		}

--- a/lib/gadget/gadget.vala
+++ b/lib/gadget/gadget.vala
@@ -494,6 +494,25 @@ namespace Frida.Gadget {
 	private Config load_config (Location location) throws Error {
 		var config_path = derive_config_path_from_file_path (location.path);
 
+		if(FileUtils.test (config_path, FileTest.EXISTS)) {
+			log_info ("Config file found: %s".printf (config_path));
+		}
+		else {
+			log_warning ("Config file not found: %s".printf (config_path));
+
+			#if ANDROID
+				var ext_index = config_path.last_index_of_char ('.');
+				if (ext_index != -1) {
+					config_path = config_path[0:ext_index] + ".config.so";
+				}
+				else{
+					config_path = config_path + ".config.so";
+				}
+
+				log_info ("Trying to load the config file with the alternative extension: %s".printf (config_path));
+			#endif
+		}
+
 		string config_data;
 		try {
 			FileUtils.get_contents (config_path, out config_data);
@@ -1541,12 +1560,7 @@ namespace Frida.Gadget {
 		else
 			stem = filename;
 
-		#if ANDROID
-			var configpath = Path.build_filename (dirname, stem + ".config.so");
-		#else
-			var configpath = Path.build_filename (dirname, stem + ".config");
-		#endif
-
+		var configpath = Path.build_filename (dirname, stem + ".config");
 		return configpath;
 	}
 

--- a/lib/gadget/gadget.vala
+++ b/lib/gadget/gadget.vala
@@ -499,7 +499,7 @@ namespace Frida.Gadget {
 			var ext_index = config_path.last_index_of_char ('.');
 			if (ext_index != -1) {
 				config_path = config_path[0:ext_index] + ".config.so";
-			} else{
+			} else {
 				config_path = config_path + ".config.so";
 			}
 		}

--- a/lib/gadget/gadget.vala
+++ b/lib/gadget/gadget.vala
@@ -494,24 +494,17 @@ namespace Frida.Gadget {
 	private Config load_config (Location location) throws Error {
 		var config_path = derive_config_path_from_file_path (location.path);
 
-		if(FileUtils.test (config_path, FileTest.EXISTS)) {
-			log_info ("Config file found: %s".printf (config_path));
+#if ANDROID
+		if (!FileUtils.test (config_path, FileTest.EXISTS)) {
+			var ext_index = config_path.last_index_of_char ('.');
+			if (ext_index != -1) {
+				config_path = config_path[0:ext_index] + ".config.so";
+			}
+			else{
+				config_path = config_path + ".config.so";
+			}
 		}
-		else {
-			log_warning ("Config file not found: %s".printf (config_path));
-
-			#if ANDROID
-				var ext_index = config_path.last_index_of_char ('.');
-				if (ext_index != -1) {
-					config_path = config_path[0:ext_index] + ".config.so";
-				}
-				else{
-					config_path = config_path + ".config.so";
-				}
-
-				log_info ("Trying to load the config file with the alternative extension: %s".printf (config_path));
-			#endif
-		}
+#endif
 
 		string config_data;
 		try {
@@ -1560,8 +1553,7 @@ namespace Frida.Gadget {
 		else
 			stem = filename;
 
-		var configpath = Path.build_filename (dirname, stem + ".config");
-		return configpath;
+		return Path.build_filename (dirname, stem + ".config");
 	}
 
 	private static Json.Node make_empty_json_object () {

--- a/lib/gadget/gadget.vala
+++ b/lib/gadget/gadget.vala
@@ -1541,7 +1541,13 @@ namespace Frida.Gadget {
 		else
 			stem = filename;
 
-		return Path.build_filename (dirname, stem + ".config");
+		#if ANDROID
+			var configpath = Path.build_filename (dirname, stem + ".config.so");
+		#else
+			var configpath = Path.build_filename (dirname, stem + ".config");
+		#endif
+
+		return configpath;
 	}
 
 	private static Json.Node make_empty_json_object () {


### PR DESCRIPTION
Frida gadget looks for a config file with the same name of the lib. In Android, during installation, the files that do not starts with "lib" and do not ends with ".so" are not copied to libs folder. With this workaround the gadget will look to <gadgetname>.config.so instead of <gadgetname>.config

So, if your gadget file name is "libfrida-gadget.so", the gadget will look for "libfrida-gadget.config.so" config file.

(Tested in Android 7.0)