### PR TITLE
Fix legacy iOS 32-bit device(pre-armv8) spawn issue

### DIFF
--- a/src/darwin/frida-helper-backend-glue.m
+++ b/src/darwin/frida-helper-backend-glue.m
@@ -62,7 +62,7 @@ union _FridaDebugState
 #ifdef HAVE_I386
   x86_debug_state_t state;
 #else
-  arm_debug_state32_t s32;
+  arm_debug_state_t s32;
   arm_debug_state64_t s64;
 #endif
 };
@@ -2907,8 +2907,8 @@ frida_get_debug_state (mach_port_t thread, gpointer state, GumCpuType cpu_type)
   }
   else
   {
-    state_count = ARM_DEBUG_STATE32_COUNT;
-    ret = thread_get_state (thread, ARM_DEBUG_STATE32, state, &state_count);
+    state_count = ARM_DEBUG_STATE_COUNT;
+    ret = thread_get_state (thread, ARM_DEBUG_STATE, state, &state_count);
   }
 #endif
 
@@ -2932,8 +2932,8 @@ frida_set_debug_state (mach_port_t thread, gconstpointer state, GumCpuType cpu_t
   }
   else
   {
-    state_count = ARM_DEBUG_STATE32_COUNT;
-    ret = thread_set_state (thread, ARM_DEBUG_STATE32, (thread_state_t) state, state_count);
+    state_count = ARM_DEBUG_STATE_COUNT;
+    ret = thread_set_state (thread, ARM_DEBUG_STATE, (thread_state_t) state, state_count);
   }
 #endif
 
@@ -2974,7 +2974,7 @@ frida_set_hardware_breakpoint (gpointer state, GumAddress break_at, GumCpuType c
   }
   else
   {
-    arm_debug_state32_t * s = state;
+    arm_debug_state_t * s = state;
 
     s->__bvr[0] = break_at;
     s->__bcr[0] = (FRIDA_BAS_ANY << 5) | FRIDA_S_USER | FRIDA_BCR_ENABLE;


### PR DESCRIPTION
### Fix:
- frida/frida#376
- frida/frida#373
- frida/frida#245
- frida/frida#211
- frida/frida-core#159
- frida/frida-core#102
- frida/frida-python#102

### Write-up:
Please view the newer iPhoneOS.sdk(e.g. iPhoneOS10.3.sdk) headers and XNU source.
(`iPhoneOS.sdk/usr/include/mach/arm/_structs.h`,  `iPhoneOS.sdk/usr/include/mach/arm/thread_status.h`, [apple/darwin-xnu/blob/master/osfmk/arm/machine_task.c](https://github.com/apple/darwin-xnu/blob/0a798f6738bc1db01281fc08ae024145e84df927/osfmk/arm/machine_task.c))

#### Frida use `ARM_DEBUG_STATE32` instead of `ARM_DEBUG_STATE`, it causes the legacy iOS kernel task switch return `KERN_INVALID_ARGUMENT`, and make `CHECK_MACH_RESULT` go to `handle_mach_error`.

_structs.h:
```C
typedef _STRUCT_ARM_DEBUG_STATE32		arm_debug_state32_t;
typedef _STRUCT_ARM_DEBUG_STATE64		arm_debug_state64_t;

/*
 * Otherwise not ARM64 kernel and we must preserve legacy ARM definitions of
 * arm_debug_state for binary compatability of userland consumers of this file.
 */
#if defined(__arm__)
typedef _STRUCT_ARM_DEBUG_STATE			arm_debug_state_t;
#elif defined(__arm64__)
typedef _STRUCT_ARM_LEGACY_DEBUG_STATE		arm_debug_state_t;
#else
#error Undefined architecture
#endif

...

#define ARM_DEBUG_STATE_COUNT ((mach_msg_type_number_t) \
   (sizeof (arm_debug_state_t)/sizeof(uint32_t)))

#define ARM_DEBUG_STATE32_COUNT ((mach_msg_type_number_t) \
   (sizeof (arm_debug_state32_t)/sizeof(uint32_t)))

#define ARM_DEBUG_STATE64_COUNT ((mach_msg_type_number_t) \
   (sizeof (arm_debug_state64_t)/sizeof(uint32_t)))
```

thread_status.h:
```C
#define ARM_DEBUG_STATE			4 /* pre-armv8 */

...

/* API */
#define ARM_DEBUG_STATE32		14
#define ARM_DEBUG_STATE64		15
```

### Test:
Tested on iPhone4,1 9.0.2.

### BTW:
I notice that [frida/frida-gum/gum/backend-darwin/gumdarwin.h#L52-L59](https://github.com/frida/frida-gum/blob/5cfcaaa4f63eac08f53fe34bf4a0bbf301ca2c80/gum/backend-darwin/gumdarwin.h#L52-L59) use `STATE32` too, but I don't know whether it is right or wrong, I tested spawn only.