### PR TITLE
Fix iOS 32-bit device (iOS 10) spawn compatibility

### DIFF
--- a/src/darwin/agent/launchd.js
+++ b/src/darwin/agent/launchd.js
@@ -52,7 +52,7 @@ Interceptor.attach(Module.findExportByName('/usr/lib/system/libsystem_kernel.dyl
 
     var identifier, event;
     if (rawIdentifier.indexOf('UIKitApplication:') === 0) {
-      identifier = rawIdentifier.substring(17, rawIdentifier.lastIndexOf('['));
+      identifier = rawIdentifier.substring(17, rawIdentifier.indexOf('['));
       if (upcoming[identifier] !== undefined)
         event = 'launch:app';
       else if (gating)

--- a/tests/test-agent.vala
+++ b/tests/test-agent.vala
@@ -163,7 +163,7 @@ Interceptor.attach(Module.findExportByName('/usr/lib/system/libsystem_kernel.dyl
 
     var identifier, event;
     if (rawIdentifier.indexOf('UIKitApplication:') === 0) {
-      identifier = rawIdentifier.substring(17, rawIdentifier.lastIndexOf('['));
+      identifier = rawIdentifier.substring(17, rawIdentifier.indexOf('['));
       if (upcoming[identifier] !== undefined)
         event = 'launch:app';
       else if (gating)


### PR DESCRIPTION
### Issue:
rawIdentifier is a little different(tested on iPhone5,2 iOS 10.3.3), take a look at the following.

```
$ frida -U -l launchd.js -p 1
     ____
    / _  |   Frida 10.6.40 - A world-class dynamic instrumentation framework
   | (_| |
    > _  |   Commands:
   /_/ |_|       help      -> Displays the help system
   . . . .       object?   -> Display information about 'object'
   . . . .       exit/quit -> Exit
   . . . .
   . . . .   More info at http://www.frida.re/docs/home/
Attaching... 
[iPhone::PID::1]-> path = /usr/libexec/xpcproxy
rawIdentifier = UIKitApplication:com.google.chrome.ios[0xefd8][64]
path = /usr/libexec/xpcproxy
rawIdentifier = UIKitApplication:com.apple.AppStore[0xc73][64]
path = /usr/libexec/xpcproxy
rawIdentifier = UIKitApplication:com.apple.Preferences[0x4443][64]
```

There is an extra string "[64]", and at `frida-core/src/darwin/agent/launchd.js` line 55, `lastIndexOf` catch the last '[', thus substring produces incorrect identifier.

### Solution:
Simply change `lastIndexOf` to `indexOf`.
