### PR TITLE
Allow mapped_range to be passed on gadget load()

### DIFF
--- a/lib/gadget/gadget-glue.c
+++ b/lib/gadget/gadget-glue.c
@@ -72,13 +72,7 @@ static void on_keep_alive_timer_fire (CFRunLoopTimerRef timer, void * info);
 static FridaFoundationApi * frida_foundation_api_try_get (void);
 static FridaCFApi * frida_cf_api_try_get (void);
 static FridaObjCApi * frida_objc_api_try_get (void);
-static gboolean frida_dylib_range_try_get (const char * apple[], GumMemoryRange * range);
-
-# if GLIB_SIZEOF_VOID_P == 4
-#  define GUM_PFMT "%llx"
-# else
-#  define GUM_PFMT "%lx"
-# endif
+static gboolean frida_dylib_range_try_get (const gchar * apple[], GumMemoryRange * range);
 
 #endif
 
@@ -610,16 +604,17 @@ frida_objc_api_try_get (void)
 }
 
 static gboolean
-frida_dylib_range_try_get (const char * apple[], GumMemoryRange * range)
+frida_dylib_range_try_get (const gchar * apple[], GumMemoryRange * range)
 {
-  const char * entry;
-  int i = 0;
+  const gchar * entry;
+  guint i = 0;
 
   while ((entry = apple[i++]) != NULL)
   {
-    if (!strncmp (entry, "frida_dylib_range=", 18))
+    if (g_str_has_prefix (entry, "frida_dylib_range="))
     {
-      if (sscanf (entry, "frida_dylib_range=0x" GUM_PFMT ",0x%lx", &range->base_address, &range->size) == 2)
+      if (sscanf (entry, "frida_dylib_range=0x%" G_GINT64_MODIFIER "x,0x%" G_GSIZE_MODIFIER "x",
+          &range->base_address, &range->size) == 2)
         return TRUE;
     }
   }

--- a/lib/gadget/gadget-glue.c
+++ b/lib/gadget/gadget-glue.c
@@ -72,6 +72,13 @@ static void on_keep_alive_timer_fire (CFRunLoopTimerRef timer, void * info);
 static FridaFoundationApi * frida_foundation_api_try_get (void);
 static FridaCFApi * frida_cf_api_try_get (void);
 static FridaObjCApi * frida_objc_api_try_get (void);
+static gboolean frida_dylib_range_try_get (const char * apple[], GumMemoryRange * range);
+
+# if GLIB_SIZEOF_VOID_P == 4
+#  define GUM_PFMT "%llx"
+# else
+#  define GUM_PFMT "%lx"
+# endif
 
 #endif
 
@@ -93,7 +100,7 @@ DllMain (HINSTANCE instance, DWORD reason, LPVOID reserved)
   switch (reason)
   {
     case DLL_PROCESS_ATTACH:
-      frida_gadget_load ();
+      frida_gadget_load (NULL);
       break;
     case DLL_PROCESS_DETACH:
       frida_gadget_unload ();
@@ -127,11 +134,28 @@ _frida_gadget_kill (guint pid)
 
 #else
 
+# ifdef HAVE_DARWIN
+
+__attribute__ ((constructor)) static void
+on_load (int argc, const char * argv[], const char * envp[], const char * apple[])
+{
+  GumMemoryRange frida_dylib_range;
+
+  if (frida_dylib_range_try_get (apple, &frida_dylib_range))
+    frida_gadget_load (&frida_dylib_range);
+  else
+    frida_gadget_load (NULL);
+}
+
+# else
+
 __attribute__ ((constructor)) static void
 on_load (void)
 {
-  frida_gadget_load ();
+  frida_gadget_load (NULL);
 }
+
+# endif
 
 __attribute__ ((destructor)) static void
 on_unload (void)
@@ -583,6 +607,24 @@ frida_objc_api_try_get (void)
   api = GSIZE_TO_POINTER (api_value - 1);
 
   return api;
+}
+
+static gboolean
+frida_dylib_range_try_get (const char * apple[], GumMemoryRange * range)
+{
+  const char * entry;
+  int i = 0;
+
+  while ((entry = apple[i++]) != NULL)
+  {
+    if (!strncmp (entry, "frida_dylib_range=", 18))
+    {
+      if (sscanf (entry, "frida_dylib_range=0x" GUM_PFMT ",0x%lx", &range->base_address, &range->size) == 2)
+        return TRUE;
+    }
+  }
+
+  return FALSE;
 }
 
 #endif

--- a/lib/gadget/gadget.vala
+++ b/lib/gadget/gadget.vala
@@ -295,7 +295,7 @@ namespace Frida.Gadget {
 	private Mutex mutex;
 	private Cond cond;
 
-	public void load () {
+	public void load (Gum.MemoryRange? mapped_range) {
 		if (loaded)
 			return;
 		loaded = true;
@@ -313,7 +313,10 @@ namespace Frida.Gadget {
 
 		Gum.Process.set_code_signing_policy (config.code_signing);
 
-		Gum.Cloak.add_range (location.range);
+		if (mapped_range != null)
+			Gum.Cloak.add_range (mapped_range);
+		else
+			Gum.Cloak.add_range (location.range);
 
 		wait_for_resume_needed = true;
 


### PR DESCRIPTION
- for proper cloaking
- implemented for i/macOS
- as a special entry in apple[] array
- if that’s not present, then fallback to usual behavior