### PR TITLE
Fix some issues with uclibc and MIPS support

### DIFF
--- a/lib/agent/syscall-linux-mips.S
+++ b/lib/agent/syscall-linux-mips.S
@@ -43,25 +43,25 @@
 ENTRY_PRIVATE(syscall)
   .set noreorder
   .cpload t9
-  move    v0, a0
-  move    a0, a1
-  move    a1, a2
-  move    a2, a3
-  lw      a3, 16(sp)
-  lw      t0, 20(sp)
-  lw      t1, 24(sp)
-  subu    sp, STACKSIZE
-  sw      t0, 16(sp)
-  sw      t1, 20(sp)
+  move    $v0, $a0
+  move    $a0, $a1
+  move    $a1, $a2
+  move    $a2, $a3
+  lw      $a3, 16($sp)
+  lw      $t0, 20($sp)
+  lw      $t1, 24($sp)
+  subu    $sp, STACKSIZE
+  sw      $t0, 16($sp)
+  sw      $t1, 20($sp)
   syscall
-  addu    sp, STACKSIZE
-  bnez    a3, 1f
-  move    a0, v0
-  j       ra
+  addu    $sp, STACKSIZE
+  bnez    $a3, 1f
+  move    $a0, $v0
+  j       $ra
   nop
 1:
-  la      t9, frida_set_errno
-  j       t9
+  la      $t9, frida_set_errno
+  j       $t9
   nop
   .set reorder
 END(syscall)

--- a/src/linux/frida-helper-service-glue.c
+++ b/src/linux/frida-helper-service-glue.c
@@ -1529,7 +1529,7 @@ frida_inject_instance_emit_payload_code (const FridaInjectParams * params, GumAd
         2,
         ARG_REG (R0),
         ARG_IMM (FRIDA_REMOTE_DATA_FIELD (pthread_detach_string)));
-    EMIT_MOV (R3, R0);
+    EMIT_MOVE (R3, R0);
 #endif
     EMIT_LOAD_FIELD (R0, worker_thread);
     EMIT_CALL_REG (R3,
@@ -1750,7 +1750,7 @@ frida_inject_instance_emit_payload_code (const FridaInjectParams * params, GumAd
         2,
         ARG_REG (X0),
         ARG_IMM (FRIDA_REMOTE_DATA_FIELD (pthread_detach_string)));
-    EMIT_MOV (X5, X0);
+    EMIT_MOVE (X5, X0);
 #endif
     EMIT_LOAD_FIELD (X0, worker_thread);
     EMIT_CALL_REG (X5,

--- a/src/linux/frida-helper-service-glue.c
+++ b/src/linux/frida-helper-service-glue.c
@@ -572,10 +572,10 @@ _frida_helper_service_do_inject (FridaHelperService * self, guint pid, const gch
   params.dlclose_impl = frida_resolve_libc_function (pid, "__libc_dlclose");
   params.dlsym_impl = frida_resolve_libc_function (pid, "__libc_dlsym");
 #elif defined (HAVE_UCLIBC)
-  params.dlopen_impl = frida_resolve_linker_address (params->pid, dlopen);
+  params.dlopen_impl = frida_resolve_linker_address (params.pid, dlopen);
   params.dlopen_pic_value = 0;
-  params.dlclose_impl = frida_resolve_linker_address (params->pid, dlclose);
-  params.dlsym_impl = frida_resolve_linker_address (params->pid, dlsym);
+  params.dlclose_impl = frida_resolve_linker_address (params.pid, dlclose);
+  params.dlsym_impl = frida_resolve_linker_address (params.pid, dlsym);
 #elif defined (HAVE_ANDROID)
   params.dlopen_impl = frida_resolve_inner_dlopen (pid, &params.dlopen_pic_value);
   params.dlclose_impl = frida_resolve_linker_address (pid, dlclose);


### PR DESCRIPTION
This fixes the MIPS ASM syntax errors, as well as changing the syntax for struct field access using uclibc. I am not sure if the latter is a overarching issue, but I had issues while trying to compile.