### PR TITLE
Refactor i/macOS early instrumentation

### DIFF
--- a/src/darwin/frida-helper-backend-glue.m
+++ b/src/darwin/frida-helper-backend-glue.m
@@ -1728,36 +1728,6 @@ failure:
   }
 }
 
-static gboolean
-frida_is_hardware_breakpoint_support_working (void)
-{
-#ifdef HAVE_IOS
-  static gsize cached_result = 0;
-
-  if (g_once_init_enter (&cached_result))
-  {
-    char buf[256];
-    size_t size;
-    int res;
-    float version;
-    gboolean buggy_kernel;
-
-    size = sizeof (buf);
-    res = sysctlbyname ("kern.osrelease", buf, &size, NULL, 0);
-    g_assert_cmpint (res, ==, 0);
-
-    version = atof (buf);
-    buggy_kernel = version >= 17.5f && version < 18.0f;
-
-    g_once_init_leave (&cached_result, !buggy_kernel + 1);
-  }
-
-  return cached_result - 1;
-#else
-  return TRUE;
-#endif
-}
-
 void
 _frida_darwin_helper_backend_resume_spawn_instance (FridaDarwinHelperBackend * self, void * instance)
 {
@@ -4229,6 +4199,36 @@ frida_set_hardware_single_step (gpointer debug_state, GumDarwinUnifiedThreadStat
     else
       s->__mdscr_el1 = 0;
   }
+#endif
+}
+
+static gboolean
+frida_is_hardware_breakpoint_support_working (void)
+{
+#ifdef HAVE_IOS
+  static gsize cached_result = 0;
+
+  if (g_once_init_enter (&cached_result))
+  {
+    char buf[256];
+    size_t size;
+    int res;
+    float version;
+    gboolean buggy_kernel;
+
+    size = sizeof (buf);
+    res = sysctlbyname ("kern.osrelease", buf, &size, NULL, 0);
+    g_assert_cmpint (res, ==, 0);
+
+    version = atof (buf);
+    buggy_kernel = version >= 17.5f && version < 18.0f;
+
+    g_once_init_leave (&cached_result, !buggy_kernel + 1);
+  }
+
+  return cached_result - 1;
+#else
+  return TRUE;
 #endif
 }
 

--- a/src/darwin/frida-helper-backend-glue.m
+++ b/src/darwin/frida-helper-backend-glue.m
@@ -34,8 +34,8 @@
 #endif
 
 #define FRIDA_PSR_THUMB                  0x20
-#define FRIDA_MAX_BREAKPOINTS 4
-#define FRIDA_MAX_PAGE_POOL 8
+#define FRIDA_MAX_BREAKPOINTS            4
+#define FRIDA_MAX_PAGE_POOL              8
 
 #define CHECK_MACH_RESULT(n1, cmp, n2, op) \
   if (!(n1 cmp n2)) \


### PR DESCRIPTION
- simplify the logic, by having a single interface for setting breakpoints and a single place to set the thread and debug states
- implement software breakpoints on iOS versions from 11.3.1 up to and including 11.4.1 where hardware breakpoints are broken in the kernel
- use hardware single step to get out of repeatable breakpoint on all platform, saving a call to capstone
- implement the `getThreadBufferFor_dlerror` helpers function using breakpoints,  needed for iOS 11.3.1

Tested on iOS 9.0.2, 9.3.3, 10.2, 11.1.2, 11.3.1.

According to my tests, the performance of software breakpoints seems about the same as hardware breakpoints.

this should fix https://github.com/frida/frida-core/issues/193
