### PR TITLE
[FIX] Fix attach to a ELF with header is only readable

### DIFF
--- a/src/linux/frida-helper-service-glue.c
+++ b/src/linux/frida-helper-service-glue.c
@@ -2066,7 +2066,7 @@ frida_run_to_entry_point (pid_t pid, GError ** error)
     goto probe_failed;
   ctx.path[length] = '\0';
   ctx.entry_point = 0;
-  gum_linux_enumerate_ranges (pid, GUM_PAGE_RX, frida_examine_range_for_elf_header, &ctx);
+  gum_linux_enumerate_ranges (pid, GUM_PAGE_READ, frida_examine_range_for_elf_header, &ctx);
   if (ctx.entry_point == 0)
     goto probe_failed;
 


### PR DESCRIPTION
Since binutils 2.31, the options --enable-separate-code is enabled by default for Linux x86 binaries.
(see changelog https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=blob_plain;f=ld/NEWS;hb=refs/tags/binutils-2_31)
This new version of binutils is the version of last Debian Unstable.

You can still compile your binaries with the option "-z no-separate-code" in gcc, but frida should be able to support this.


This breaks frida on several points I have identified for now:

- Attaching, frida cannot find entry point, because it search for a RX region
- Finding DebugSymbols, but did not find the code that handle this (but probably for the same reason of above). If you could point me the portion of code that handles a simple "DebugSymbol.fromName()" I would be glad to fix it.
- Probably some other things, but that I have not identify for now

This commit only fix the first point, I hope you can help me finding the other bugs implied, or fix them by yourself.