### PR TITLE
Add support for spawning Android broadcast receivers

### DIFF
--- a/src/linux/agent/systemui.js
+++ b/src/linux/agent/systemui.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var ApplicationInfo, RunningAppProcessInfo, RunningTaskInfo, GET_META_DATA;
+var ApplicationInfo, ComponentName, Intent, RunningAppProcessInfo, RunningTaskInfo, GET_META_DATA;
 var context, packageManager, activityManager;
 
 rpc.exports = {
@@ -17,8 +17,8 @@ rpc.exports = {
         var process = Java.cast(processes.get(i), RunningAppProcessInfo);
         pid = process.pid.value;
         var pkgList = process.pkgList.value;
-        pkgList.forEach(function (packageName) {
-          appPids[packageName] = pid;
+        pkgList.forEach(function (pkg) {
+          appPids[pkg] = pid;
         });
       }
 
@@ -26,34 +26,43 @@ rpc.exports = {
       var numApps = apps.size();
       for (i = 0; i !== numApps; i++) {
         var app = Java.cast(apps.get(i), ApplicationInfo);
-        var packageName = app.packageName.value;
+        var pkg = app.packageName.value;
         var name = app.loadLabel(packageManager).toString();
-        pid = appPids[packageName] || 0;
-        result.push([packageName, name, pid]);
+        pid = appPids[pkg] || 0;
+        result.push([pkg, name, pid]);
       }
 
       return result;
     });
   },
-  getProcessName: function (packageName) {
+  getProcessName: function (pkg) {
     return performOnJavaVM(function () {
       try {
-        return packageManager.getApplicationInfo(packageName, GET_META_DATA).processName.value;
+        return packageManager.getApplicationInfo(pkg, GET_META_DATA).processName.value;
       } catch (e) {
-        throw new Error("Unable to find application with identifier '" + packageName + "'");
+        throw new Error("Unable to find application with identifier '" + pkg + "'");
       }
     });
   },
-  startActivity: function (packageName, activityName) {
+  startActivity: function (pkg, activity) {
     return performOnJavaVM(function () {
-      var launchIntent = packageManager.getLaunchIntentForPackage(packageName);
-      if (launchIntent === null)
-        throw new Error("Unable to find application with identifier '" + packageName + "'");
+      var intent = packageManager.getLaunchIntentForPackage(pkg);
+      if (intent === null)
+        throw new Error("Unable to find application with identifier '" + pkg + "'");
 
-      if (activityName !== null)
-        launchIntent.setClassName(packageName, activityName);
+      if (activity !== null)
+        intent.setClassName(pkg, activity);
 
-      context.startActivity(launchIntent);
+      context.startActivity(intent);
+    });
+  },
+  sendBroadcast: function (pkg, receiver, action) {
+    return performOnJavaVM(function () {
+      var intent = Intent.$new();
+      intent.setComponent(ComponentName.$new(pkg, receiver));
+      intent.setAction(action);
+
+      context.sendBroadcast(intent);
     });
   },
   getFrontmostApplication: function () {
@@ -66,7 +75,7 @@ rpc.exports = {
         if (typeof runningTaskInfo.topActivity !== 'undefined') {
           var topActivity = runningTaskInfo.topActivity.value;
           var app = packageManager.getApplicationInfo(topActivity.getPackageName(), GET_META_DATA);
-          var packageName = app.packageName.value;
+          var pkg = app.packageName.value;
           var name = app.loadLabel(packageManager).toString();
 
           var processes = activityManager.getRunningAppProcesses();
@@ -75,13 +84,13 @@ rpc.exports = {
           for (var i = 0; i !== numProcesses; i++) {
             var process = Java.cast(processes.get(i), RunningAppProcessInfo);
             var pkgList = process.pkgList.value;
-            if (pkgList.indexOf(packageName) > -1) {
+            if (pkgList.indexOf(pkg) > -1) {
               pid = process.pid.value;
               break;
             }
           }
 
-          result = [packageName, name, pid];
+          result = [pkg, name, pid];
         }
       }
 
@@ -108,6 +117,8 @@ Java.perform(function () {
   var ActivityManager = Java.use('android.app.ActivityManager');
   var ActivityThread = Java.use('android.app.ActivityThread');
   ApplicationInfo = Java.use('android.content.pm.ApplicationInfo');
+  ComponentName = Java.use('android.content.ComponentName');
+  Intent = Java.use('android.content.Intent');
   var Context = Java.use('android.content.Context');
   var PackageManager = Java.use('android.content.pm.PackageManager');
   RunningAppProcessInfo = Java.use('android.app.ActivityManager$RunningAppProcessInfo');


### PR DESCRIPTION
By specifying the `receiver` and `action` aux options.

Also be as forgiving as the system if the class name is bare and does
not start with a period.

(Based on #212.)