### PR TITLE
Adding support for systemless root

### DIFF
--- a/src/linux/frida-helper-service-glue.c
+++ b/src/linux/frida-helper-service-glue.c
@@ -3051,7 +3051,7 @@ frida_find_library_base (pid_t pid, const gchar * library_name, gchar ** library
         *library_path = g_strdup (path);
     }
 #ifdef HAVE_ANDROID
-    else if (g_str_has_prefix (path, "/system_root") && strcmp (&path[strlen("/system_root")], library_name) == 0)
+    else if (g_str_has_prefix (path, "/system_root") && strcmp (path + strlen ("/system_root"), library_name) == 0)
     {
       result = start;
       if (library_path != NULL)

--- a/src/linux/frida-helper-service-glue.c
+++ b/src/linux/frida-helper-service-glue.c
@@ -3033,7 +3033,7 @@ frida_find_library_base (pid_t pid, const gchar * library_name, gchar ** library
 
   while (result == 0 && fgets (line, line_size, fp) != NULL)
   {
-    guint64 start;
+    GumAddress start;
     gint n;
 
     n = sscanf (line, "%" G_GINT64_MODIFIER "x-%*x %*s %*x %*s %*s %s", &start, path);
@@ -3050,6 +3050,14 @@ frida_find_library_base (pid_t pid, const gchar * library_name, gchar ** library
       if (library_path != NULL)
         *library_path = g_strdup (path);
     }
+#ifdef HAVE_ANDROID
+    else if (g_str_has_prefix (path, "/system_root") && strcmp (&path[strlen("/system_root")], library_name) == 0)
+    {
+      result = start;
+      if (library_path != NULL)
+        *library_path = g_strdup (path);
+    }
+#endif
     else
     {
       gchar * p = strrchr (path, '/');


### PR DESCRIPTION
A lot of rooted Android devices are doing so called "systemless root". One particular example is the Pixel root by Chainfire. In it, the system partition is moved to "system_root", so searching for things like "/system/bin/linker" fails. 

This patch lets Frida work on systemless rooted Android devices. 