### PR TITLE
Avoid deadlock when a thread suspends itself

### DIFF
--- a/lib/agent/agent.vala
+++ b/lib/agent/agent.vala
@@ -1720,8 +1720,8 @@ namespace Frida.Agent {
 			if (Gum.Cloak.has_thread (thread_id))
 				return 0;
 
-			uint caller_thread_id = (uint) Gum.Process.get_current_thread_id ();
 			var script_backend = Runner.shared_instance.script_backend;
+			uint caller_thread_id = (uint) Gum.Process.get_current_thread_id ();
 			if (script_backend == null || thread_id == caller_thread_id)
 				return thread_suspend (thread_id);
 

--- a/lib/agent/agent.vala
+++ b/lib/agent/agent.vala
@@ -1720,8 +1720,9 @@ namespace Frida.Agent {
 			if (Gum.Cloak.has_thread (thread_id))
 				return 0;
 
+			uint caller_thread_id = (uint) Gum.Process.get_current_thread_id ();
 			var script_backend = Runner.shared_instance.script_backend;
-			if (script_backend == null)
+			if (script_backend == null || thread_id == caller_thread_id)
 				return thread_suspend (thread_id);
 
 			int result = 0;


### PR DESCRIPTION
By calling `thread_suspend` right away without getting locks.