### PR TITLE
frida-inject: read script from stdin if dash is specified

### DIFF
--- a/inject/inject.vala
+++ b/inject/inject.vala
@@ -54,7 +54,7 @@ namespace Frida.Inject {
 			printerr ("Path to JavaScript file must be specified\n");
 			return 3;
 		} else if (script_path == "-") {
-		    script_path = null;
+			script_path = null;
 			script_source = read_stdin ();
 		}
 

--- a/inject/inject.vala
+++ b/inject/inject.vala
@@ -242,7 +242,7 @@ namespace Frida.Inject {
 		public async void start () throws Error {
 			yield load ();
 
-			if (enable_development) {
+			if (enable_development && script_path != null) {
 				try {
 					script_monitor = File.new_for_path (script_path).monitor_file (FileMonitorFlags.NONE);
 					script_monitor.changed.connect (on_script_file_changed);
@@ -287,7 +287,7 @@ namespace Frida.Inject {
 			try {
 				string name;
 				string source;
-				if (script_source == null) {
+				if (script_path != null) {
 					name = Path.get_basename (script_path).split (".", 2)[0];
 					try {
 						FileUtils.get_contents (script_path, out source);

--- a/inject/inject.vala
+++ b/inject/inject.vala
@@ -48,12 +48,13 @@ namespace Frida.Inject {
 			return 2;
 		}
 
-		string? script_source = null;
-
 		if (script_path == null || script_path == "") {
 			printerr ("Path to JavaScript file must be specified\n");
 			return 3;
-		} else if (script_path == "-") {
+		}
+
+		string? script_source = null;
+		if (script_path == "-") {
 			script_path = null;
 			script_source = read_stdin ();
 		}
@@ -286,7 +287,6 @@ namespace Frida.Inject {
 			try {
 				string name;
 				string source;
-
 				if (script_source == null) {
 					name = Path.get_basename (script_path).split (".", 2)[0];
 					try {


### PR DESCRIPTION
Scenario: i recently bought an android device which needs to do something through injector.
This device for some reason that i don't want to know doesn't allow "setenforce 0" on the stock kernel.
The enforcing selinux doesn't allow frida injector to read files from outside it's context.
An higher level solution wich would bring benefit in other situations would be providing the script source straight to the injector through other ways.
Discussed with the owner both, a base64'd input to avoid issues with \n or an input to the stdin (through outputstream).
I'm gonna use this through an android app which uses Process to run a su -c command to invoke the injector. Tested and working by providing the script to the outputstream
and later by closing it (eof).