### PR TITLE
Handle cloaked threads in task_threads and thread_resume

### DIFF
--- a/lib/agent/agent-glue.c
+++ b/lib/agent/agent-glue.c
@@ -221,7 +221,7 @@ frida_ansi_string_to_utf8 (const gchar * str_ansi, gint length)
 #ifdef HAVE_DARWIN
 
 void
-_frida_agent_thread_suspend_monitor_remove_cloaked_threads (FridaAgentThreadSuspendMonitor * self, task_inspect_t task, thread_act_array_t * threads, mach_msg_type_number_t * count)
+_frida_agent_thread_suspend_monitor_remove_cloaked_threads (task_inspect_t task, thread_act_array_t * threads, mach_msg_type_number_t * count)
 {
   guint i, o;
   thread_act_array_t old_threads = *threads;

--- a/lib/agent/agent-glue.c
+++ b/lib/agent/agent-glue.c
@@ -221,7 +221,7 @@ frida_ansi_string_to_utf8 (const gchar * str_ansi, gint length)
 #ifdef HAVE_DARWIN
 
 void
-_frida_agent_thread_suspend_monitor_task_threads_filter (FridaAgentThreadSuspendMonitor * self, task_inspect_t task, thread_act_array_t * threads, mach_msg_type_number_t * count)
+_frida_agent_thread_suspend_monitor_remove_cloaked_threads (FridaAgentThreadSuspendMonitor * self, task_inspect_t task, thread_act_array_t * threads, mach_msg_type_number_t * count)
 {
   guint i, o;
   thread_act_array_t old_threads = *threads;
@@ -264,11 +264,6 @@ _frida_agent_thread_suspend_monitor_task_threads_filter (FridaAgentThreadSuspend
     *count = o;
   }
 }
-
-#endif
-
-
-#ifdef HAVE_DARWIN
 
 /*
  * Get rid of the -lresolv dependency until we actually need it, i.e. if/when

--- a/lib/agent/agent.vala
+++ b/lib/agent/agent.vala
@@ -1730,7 +1730,7 @@ namespace Frida.Agent {
 			return result;
 		}
 
-		public extern void _remove_cloaked_threads (uint task_id, uint ** threads, uint * count);
+		public extern static void _remove_cloaked_threads (uint task_id, uint ** threads, uint * count);
 
 		private static int replacement_thread_suspend (uint thread_id) {
 			unowned Gum.InvocationContext context = Gum.Interceptor.get_current_invocation ();

--- a/lib/agent/agent.vala
+++ b/lib/agent/agent.vala
@@ -1701,7 +1701,6 @@ namespace Frida.Agent {
 			thread_suspend = (ThreadSuspendFunc) Gum.Module.find_export_by_name (LIBSYSTEM_KERNEL, "thread_suspend");
 			thread_resume = (ThreadResumeFunc) Gum.Module.find_export_by_name (LIBSYSTEM_KERNEL, "thread_resume");
 			task_threads = (ThreadResumeFunc) Gum.Module.find_export_by_name (LIBSYSTEM_KERNEL, "task_threads");
-			
 
 			interceptor.replace_function ((void *) thread_suspend, (void *) replacement_thread_suspend, this);
 			interceptor.replace_function ((void *) thread_resume, (void *) replacement_thread_resume, this);

--- a/lib/agent/agent.vala
+++ b/lib/agent/agent.vala
@@ -1684,6 +1684,7 @@ namespace Frida.Agent {
 	public class ThreadSuspendMonitor : Object {
 		private ThreadSuspendFunc thread_resume;
 		private ThreadResumeFunc thread_suspend;
+		private TaskThreadsFunc task_threads;
 
 		private const string LIBSYSTEM_KERNEL = "/usr/lib/system/libsystem_kernel.dylib";
 
@@ -1691,14 +1692,20 @@ namespace Frida.Agent {
 		private delegate int ThreadSuspendFunc (uint thread_id);
 		[CCode (has_target = false)]
 		private delegate int ThreadResumeFunc (uint thread_id);
+		[CCode (has_target = false)]
+		private delegate int TaskThreadsFunc (uint task_id, uint ** threads, uint * count);
 
 		construct {
 			var interceptor = Gum.Interceptor.obtain ();
 
 			thread_suspend = (ThreadSuspendFunc) Gum.Module.find_export_by_name (LIBSYSTEM_KERNEL, "thread_suspend");
 			thread_resume = (ThreadResumeFunc) Gum.Module.find_export_by_name (LIBSYSTEM_KERNEL, "thread_resume");
+			task_threads = (ThreadResumeFunc) Gum.Module.find_export_by_name (LIBSYSTEM_KERNEL, "task_threads");
+			
 
 			interceptor.replace_function ((void *) thread_suspend, (void *) replacement_thread_suspend, this);
+			interceptor.replace_function ((void *) thread_resume, (void *) replacement_thread_resume, this);
+			interceptor.replace_function ((void *) task_threads, (void *) replacement_task_threads, this);
 		}
 
 		public override void dispose () {
@@ -1741,6 +1748,37 @@ namespace Frida.Agent {
 
 			return result;
 		}
+
+		private static int replacement_thread_resume (uint thread_id) {
+			unowned Gum.InvocationContext context = Gum.Interceptor.get_current_invocation ();
+			unowned ThreadSuspendMonitor monitor = (ThreadSuspendMonitor) context.get_replacement_function_data ();
+
+			return monitor.handle_thread_resume (thread_id);
+		}
+
+		private int handle_thread_resume (uint thread_id) {
+			if (Gum.Cloak.has_thread (thread_id))
+				return 0;
+
+			return thread_resume (thread_id);
+		}
+
+		private static int replacement_task_threads (uint task_id, uint ** threads, uint * count) {
+			unowned Gum.InvocationContext context = Gum.Interceptor.get_current_invocation ();
+			unowned ThreadSuspendMonitor monitor = (ThreadSuspendMonitor) context.get_replacement_function_data ();
+
+			return monitor.handle_task_threads (task_id, threads, count);
+		}
+
+		private int handle_task_threads (uint task_id, uint ** threads, uint * count) {
+			int result = task_threads (task_id, threads, count);
+
+			_task_threads_filter (task_id, threads, count);
+
+			return result;
+		}
+
+		public extern void _task_threads_filter (uint task_id, uint ** threads, uint * count);
 	}
 #endif
 


### PR DESCRIPTION
By replacing them too in `ThreadSuspendMonitor`. This avoids potential deadlocks.