### PR TITLE
Make it possible to disable tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -208,4 +208,7 @@ subdir('lib')
 subdir('src')
 subdir('server')
 subdir('inject')
-subdir('tests')
+
+if get_option('enable_tests')
+  subdir('tests')
+endif

--- a/meson.build
+++ b/meson.build
@@ -209,6 +209,6 @@ subdir('src')
 subdir('server')
 subdir('inject')
 
-if get_option('enable_tests')
+if get_option('tests')
   subdir('tests')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,4 +4,4 @@ option('with-32bit-helper', type: 'string', description: 'Prebuilt 32-bit frida-
 option('with-64bit-helper', type: 'string', description: 'Prebuilt 64-bit frida-helper')
 option('with-32bit-agent', type: 'string', description: 'Prebuilt agent to use for 32-bit targets')
 option('with-64bit-agent', type: 'string', description: 'Prebuilt agent to use for 64-bit targets')
-option('tests', type: 'boolean', value: true, description: 'build tests')
+option('tests', type: 'boolean', description: 'Build tests', value: true)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,3 +4,4 @@ option('with-32bit-helper', type: 'string', description: 'Prebuilt 32-bit frida-
 option('with-64bit-helper', type: 'string', description: 'Prebuilt 64-bit frida-helper')
 option('with-32bit-agent', type: 'string', description: 'Prebuilt agent to use for 32-bit targets')
 option('with-64bit-agent', type: 'string', description: 'Prebuilt agent to use for 64-bit targets')
+option('enable_tests', type : 'boolean', value : true, description : 'build tests')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,4 +4,4 @@ option('with-32bit-helper', type: 'string', description: 'Prebuilt 32-bit frida-
 option('with-64bit-helper', type: 'string', description: 'Prebuilt 64-bit frida-helper')
 option('with-32bit-agent', type: 'string', description: 'Prebuilt agent to use for 32-bit targets')
 option('with-64bit-agent', type: 'string', description: 'Prebuilt agent to use for 64-bit targets')
-option('enable_tests', type : 'boolean', value : true, description : 'build tests')
+option('tests', type : 'boolean', value : true, description: 'build tests')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,4 +4,4 @@ option('with-32bit-helper', type: 'string', description: 'Prebuilt 32-bit frida-
 option('with-64bit-helper', type: 'string', description: 'Prebuilt 64-bit frida-helper')
 option('with-32bit-agent', type: 'string', description: 'Prebuilt agent to use for 32-bit targets')
 option('with-64bit-agent', type: 'string', description: 'Prebuilt agent to use for 64-bit targets')
-option('tests', type : 'boolean', value : true, description: 'build tests')
+option('tests', type: 'boolean', value: true, description: 'build tests')


### PR DESCRIPTION
I suggest to make it possible to disable tests (by default, they are built). This will speed up automated builds and allow to skip failing tests (e.g. on linux-arm, cf. issue #190) until they are fixed.