### PR TITLE
Fix CreateProcessInternalW in older windows versions (child_gating)

### DIFF
--- a/lib/payload/spawn-monitor.vala
+++ b/lib/payload/spawn-monitor.vala
@@ -38,11 +38,11 @@ namespace Frida {
 			var interceptor = Gum.Interceptor.obtain ();
 
 #if WINDOWS
-      var cpiw_export = Gum.Module.find_export_by_name ("kernelbase.dll", "CreateProcessInternalW");
-      if (cpiw_export == null)
-        cpiw_export = Gum.Module.find_export_by_name ("kernel32.dll", "CreateProcessInternalW");
-	  assert(cpiw_export != null);
-	  interceptor.attach_listener (cpiw_export, this);
+		var cpiw_export = Gum.Module.find_export_by_name ("kernelbase.dll", "CreateProcessInternalW");
+		if (cpiw_export == null)
+			cpiw_export = Gum.Module.find_export_by_name ("kernel32.dll", "CreateProcessInternalW");
+		assert(cpiw_export != null);
+		interceptor.attach_listener (cpiw_export, this);
 #else
 			var libc_name = detect_libc_name ();
 #if DARWIN

--- a/lib/payload/spawn-monitor.vala
+++ b/lib/payload/spawn-monitor.vala
@@ -38,7 +38,11 @@ namespace Frida {
 			var interceptor = Gum.Interceptor.obtain ();
 
 #if WINDOWS
-			interceptor.attach_listener (Gum.Module.find_export_by_name ("kernelbase.dll", "CreateProcessInternalW"), this);
+      var cpiw_export = Gum.Module.find_export_by_name ("kernelbase.dll", "CreateProcessInternalW");
+      if (cpiw_export == null)
+        cpiw_export = Gum.Module.find_export_by_name ("kernel32.dll", "CreateProcessInternalW");
+			assert(cpiw_export != null);
+			interceptor.attach_listener (cpiw_export, this);
 #else
 			var libc_name = detect_libc_name ();
 #if DARWIN

--- a/lib/payload/spawn-monitor.vala
+++ b/lib/payload/spawn-monitor.vala
@@ -41,8 +41,8 @@ namespace Frida {
       var cpiw_export = Gum.Module.find_export_by_name ("kernelbase.dll", "CreateProcessInternalW");
       if (cpiw_export == null)
         cpiw_export = Gum.Module.find_export_by_name ("kernel32.dll", "CreateProcessInternalW");
-			assert(cpiw_export != null);
-			interceptor.attach_listener (cpiw_export, this);
+	  assert(cpiw_export != null);
+	  interceptor.attach_listener (cpiw_export, this);
 #else
 			var libc_name = detect_libc_name ();
 #if DARWIN

--- a/lib/payload/spawn-monitor.vala
+++ b/lib/payload/spawn-monitor.vala
@@ -38,11 +38,11 @@ namespace Frida {
 			var interceptor = Gum.Interceptor.obtain ();
 
 #if WINDOWS
-			var cpiw_export = Gum.Module.find_export_by_name ("kernelbase.dll", "CreateProcessInternalW");
-			if (cpiw_export == null)
-				cpiw_export = Gum.Module.find_export_by_name ("kernel32.dll", "CreateProcessInternalW");
-			assert(cpiw_export != null);
-			interceptor.attach_listener (cpiw_export, this);
+			var create_process_internal = Gum.Module.find_export_by_name ("kernelbase.dll", "CreateProcessInternalW");
+			if (create_process_internal == null)
+				create_process_internal = Gum.Module.find_export_by_name ("kernel32.dll", "CreateProcessInternalW");
+			assert (create_process_internal != null);
+			interceptor.attach_listener (create_process_internal, this);
 #else
 			var libc_name = detect_libc_name ();
 #if DARWIN

--- a/lib/payload/spawn-monitor.vala
+++ b/lib/payload/spawn-monitor.vala
@@ -38,11 +38,11 @@ namespace Frida {
 			var interceptor = Gum.Interceptor.obtain ();
 
 #if WINDOWS
-		var cpiw_export = Gum.Module.find_export_by_name ("kernelbase.dll", "CreateProcessInternalW");
-		if (cpiw_export == null)
-			cpiw_export = Gum.Module.find_export_by_name ("kernel32.dll", "CreateProcessInternalW");
-		assert(cpiw_export != null);
-		interceptor.attach_listener (cpiw_export, this);
+			var cpiw_export = Gum.Module.find_export_by_name ("kernelbase.dll", "CreateProcessInternalW");
+			if (cpiw_export == null)
+				cpiw_export = Gum.Module.find_export_by_name ("kernel32.dll", "CreateProcessInternalW");
+			assert(cpiw_export != null);
+			interceptor.attach_listener (cpiw_export, this);
 #else
 			var libc_name = detect_libc_name ();
 #if DARWIN


### PR DESCRIPTION
Related to https://github.com/frida/frida/issues/854

Frida didn't have a fallback API to call and it was sending a null address to the upcoming calls. This should fix the problem in older versions of Windows where CreateProcessInternalW is in kernel32.dll and not yet in Kernelbase.dll