### PR TITLE
Add support for specifying script options

### DIFF
--- a/inject/inject.vala
+++ b/inject/inject.vala
@@ -287,21 +287,25 @@ namespace Frida.Inject {
 			load_in_progress = true;
 
 			try {
-				string name;
 				string source;
+
+				var options = new ScriptOptions ();
+
 				if (script_path != null) {
-					name = Path.get_basename (script_path).split (".", 2)[0];
 					try {
 						FileUtils.get_contents (script_path, out source);
 					} catch (FileError e) {
 						throw new Error.INVALID_ARGUMENT (e.message);
 					}
+
+					options.name = Path.get_basename (script_path).split (".", 2)[0];
 				} else {
-					name = "frida";
 					source = script_source;
+
+					options.name = "frida";
 				}
 
-				var s = yield session.create_script (name, source);
+				var s = yield session.create_script (source, options);
 
 				if (script != null) {
 					try {

--- a/lib/agent/agent-glue.c
+++ b/lib/agent/agent-glue.c
@@ -46,20 +46,3 @@ _frida_agent_environment_deinit (void)
   frida_deinit_libc_shim ();
   gum_deinit_embedded ();
 }
-
-GumScriptBackend *
-_frida_agent_environment_obtain_script_backend (gboolean jit_enabled)
-{
-  GumScriptBackend * backend = NULL;
-
-#ifdef HAVE_DIET
-  backend = gum_script_backend_obtain_duk ();
-#else
-  if (jit_enabled)
-    backend = gum_script_backend_obtain_v8 ();
-  if (backend == NULL)
-    backend = gum_script_backend_obtain_duk ();
-#endif
-
-  return backend;
-}

--- a/lib/gadget/gadget-glue.c
+++ b/lib/gadget/gadget-glue.c
@@ -301,23 +301,6 @@ frida_gadget_environment_get_main_context (void)
   return main_context;
 }
 
-GumScriptBackend *
-frida_gadget_environment_obtain_script_backend (FridaGadgetRuntimeFlavor runtime)
-{
-  GumScriptBackend * backend = NULL;
-
-#ifdef HAVE_DIET
-  backend = gum_script_backend_obtain_duk ();
-#else
-  if (runtime == FRIDA_GADGET_RUNTIME_FLAVOR_JIT)
-    backend = gum_script_backend_obtain_v8 ();
-  if (backend == NULL)
-    backend = gum_script_backend_obtain_duk ();
-#endif
-
-  return backend;
-}
-
 gchar *
 frida_gadget_environment_detect_bundle_id (void)
 {

--- a/lib/payload/process.vala
+++ b/lib/payload/process.vala
@@ -75,4 +75,10 @@ namespace Frida {
 
 		return result;
 	}
+
+	public interface ProcessInvader : Object {
+		public abstract Gum.MemoryRange get_memory_range ();
+		public abstract Gum.ScriptBackend get_script_backend (ScriptRuntime runtime) throws Error;
+		public abstract Gum.ScriptBackend? get_active_script_backend ();
+	}
 }

--- a/lib/payload/thread-suspend-monitor.vala
+++ b/lib/payload/thread-suspend-monitor.vala
@@ -1,7 +1,7 @@
 namespace Frida {
 #if DARWIN
 	public class ThreadSuspendMonitor : Object {
-		public weak ThreadSuspendScriptRunner runner {
+		public weak ProcessInvader invader {
 			get;
 			construct;
 		}
@@ -19,8 +19,8 @@ namespace Frida {
 		[CCode (has_target = false)]
 		private delegate int ThreadResumeFunc (uint thread_id);
 
-		public ThreadSuspendMonitor (ThreadSuspendScriptRunner runner) {
-			Object (runner: runner);
+		public ThreadSuspendMonitor (ProcessInvader invader) {
+			Object (invader: invader);
 		}
 
 		construct {
@@ -71,7 +71,7 @@ namespace Frida {
 			if (Gum.Cloak.has_thread (thread_id))
 				return 0;
 
-			var script_backend = runner.get_current_script_backend ();
+			var script_backend = invader.get_active_script_backend ();
 			uint caller_thread_id = (uint) Gum.Process.get_current_thread_id ();
 			if (script_backend == null || thread_id == caller_thread_id)
 				return thread_suspend (thread_id);
@@ -109,18 +109,14 @@ namespace Frida {
 	}
 #else
 	public class ThreadSuspendMonitor : Object {
-		public weak ThreadSuspendScriptRunner runner {
+		public weak ProcessInvader invader {
 			get;
 			construct;
 		}
 
-		public ThreadSuspendMonitor (ThreadSuspendScriptRunner runner) {
-			Object (runner: runner);
+		public ThreadSuspendMonitor (ProcessInvader invader) {
+			Object (invader: invader);
 		}
 	}
 #endif
-
-	public interface ThreadSuspendScriptRunner : Object {
-		public abstract Gum.ScriptBackend? get_current_script_backend ();
-	}
 }

--- a/src/frida.vala
+++ b/src/frida.vala
@@ -1702,12 +1702,16 @@ namespace Frida {
 			}
 		}
 
-		public async Script create_script (string? name, string source) throws Error {
+		public async Script create_script (string source, ScriptOptions? options = null) throws Error {
 			check_open ();
+
+			var raw_options = AgentScriptOptions ();
+			if (options != null)
+				raw_options.data = options._serialize ().get_data ();
 
 			AgentScriptId script_id;
 			try {
-				script_id = yield session.create_script ((name == null) ? "" : name, source);
+				script_id = yield session.create_script_with_options (source, raw_options);
 			} catch (GLib.Error e) {
 				throw Marshal.from_dbus (e);
 			}
@@ -1720,28 +1724,32 @@ namespace Frida {
 			return script;
 		}
 
-		public Script create_script_sync (string? name, string source) throws Error {
+		public Script create_script_sync (string source, ScriptOptions? options = null) throws Error {
 			var task = create<CreateScriptTask> () as CreateScriptTask;
-			task.name = name;
 			task.source = source;
+			task.options = options;
 			return task.start_and_wait_for_completion ();
 		}
 
 		private class CreateScriptTask : SessionTask<Script> {
-			public string? name;
 			public string source;
+			public ScriptOptions? options;
 
 			protected override async Script perform_operation () throws Error {
-				return yield parent.create_script (name, source);
+				return yield parent.create_script (source, options);
 			}
 		}
 
-		public async Script create_script_from_bytes (Bytes bytes) throws Error {
+		public async Script create_script_from_bytes (Bytes bytes, ScriptOptions? options = null) throws Error {
 			check_open ();
+
+			var raw_options = AgentScriptOptions ();
+			if (options != null)
+				raw_options.data = options._serialize ().get_data ();
 
 			AgentScriptId script_id;
 			try {
-				script_id = yield session.create_script_from_bytes (bytes.get_data ());
+				script_id = yield session.create_script_from_bytes_with_options (bytes.get_data (), raw_options);
 			} catch (GLib.Error e) {
 				throw Marshal.from_dbus (e);
 			}
@@ -1754,17 +1762,19 @@ namespace Frida {
 			return script;
 		}
 
-		public Script create_script_from_bytes_sync (Bytes bytes) throws Error {
+		public Script create_script_from_bytes_sync (Bytes bytes, ScriptOptions? options = null) throws Error {
 			var task = create<CreateScriptFromBytesTask> () as CreateScriptFromBytesTask;
 			task.bytes = bytes;
+			task.options = options;
 			return task.start_and_wait_for_completion ();
 		}
 
 		private class CreateScriptFromBytesTask : SessionTask<Script> {
 			public Bytes bytes;
+			public ScriptOptions? options;
 
 			protected override async Script perform_operation () throws Error {
-				return yield parent.create_script_from_bytes (bytes);
+				return yield parent.create_script_from_bytes (bytes, options);
 			}
 		}
 


### PR DESCRIPTION
The only supported option for now is for explicitly picking a JavaScript
runtime. This means that enable_jit() is now deprecated, but works
better than before as there is no longer any restriction on when it may
be called. All it does now is change the default for scripts created
without specifying which runtime to use.