### PR TITLE
Fix can't find Apple USB device on Windows

### DIFF
--- a/src/fruity/fruity-host-session-windows.c
+++ b/src/fruity/fruity-host-session-windows.c
@@ -205,7 +205,11 @@ compare_location_and_create_image_device_info_if_matching (const FridaDeviceInfo
 
   friendly_name = frida_read_registry_string (devkey, L"FriendlyName");
   if (friendly_name == NULL)
-    goto keep_looking;
+  {
+    friendly_name = frida_read_registry_string (devkey, L"Label");
+    if (friendly_name == NULL)
+      goto keep_looking;
+  }
 
   icon_url = frida_read_registry_multi_string (devkey, L"Icons");
   if (icon_url == NULL)

--- a/src/fruity/fruity-host-session-windows.c
+++ b/src/fruity/fruity-host-session-windows.c
@@ -151,15 +151,34 @@ compare_udid_and_create_mobile_device_info_if_matching (const FridaDeviceInfo * 
 {
   FridaFindMobileDeviceContext * ctx = (FridaFindMobileDeviceContext *) user_data;
   WCHAR * udid, * location;
+  size_t udid_len;
 
   udid = wcsrchr (device_info->instance_id, L'\\');
   if (udid == NULL)
-    goto keep_looking;
+    goto match_devicepath;
   udid++;
 
-  if (_wcsicmp (udid, ctx->udid) != 0)
+  if (_wcsicmp (udid, ctx->udid) == 0)
+    goto match;
+
+match_devicepath:
+  udid = device_info->device_path;
+
+  if (udid == NULL)
     goto keep_looking;
 
+  udid_len = wcslen(ctx->udid);
+  while (*udid != L'\0')
+  {
+    if (_wcsnicmp(udid, ctx->udid, udid_len) == 0)
+      break;
+    udid++;
+  }
+
+  if (*udid == L'\0')
+    goto keep_looking;
+
+match:
   location = (WCHAR *) g_memdup (device_info->location, ((guint) wcslen (device_info->location) + 1) * sizeof (WCHAR));
   ctx->mobile_device = frida_mobile_device_info_new (location);
 


### PR DESCRIPTION
- fix can't find udid in instance_id, use device_path instead.
    device_path like  `\\?\usb#vid_05ac&pid_12a8&mi_01#6&f39b6b7&0&0001#{f0b32be3-6678-4879-9230-e43845d805ee}\usb#vid_05ac&pid_12a8#5e2e327fcfed253f438dc390e7e5e85913aab4a6#mux1`.

- while SetupDiOpenDevRegKey opens key not contain FriendlyName , read Label instead.

Tested on Windows 7 and 10, it's working fine.