### PR TITLE
added memcpy to libc-shim (1/2)

### DIFF
--- a/lib/payload/libc-shim.c
+++ b/lib/payload/libc-shim.c
@@ -86,6 +86,12 @@ free (void * ptr)
   gum_free (ptr);
 }
 
+void *
+memcpy (void * dst, const void * src, size_t n)
+{
+  return gum_memcpy (dst, src, n);
+}
+
 char *
 strdup (const char * s)
 {


### PR DESCRIPTION
What i'll say it's not confirmed by debugging but just by impressions:
I did worked the whole day hunting some bugs while hooking memcpy.
Before adding memcpy to the shim, the hook on memcpy hit 5/10 threads at once (tested over (50?) times on the same target).
When breakpointed, each thread was calling different frida api (the most used were DebugSymbol.fromAddress and Memory.readByteArray).
After adding the memcpy to the libc-shim, the same proc hit the hook 1/2 times. 

I didn't debugged in the deep if that's really true that some internal frida api uses memcpy so, I would like someone to confirm this in case but from what i get from @oleavr this is safe in any case to be added