### PR TITLE
Android gadget get executable name and package name

### DIFF
--- a/lib/gadget/gadget.vala
+++ b/lib/gadget/gadget.vala
@@ -313,7 +313,7 @@ namespace Frida.Gadget {
 					FileUtils.get_contents ("/proc/self/cmdline", out cmdline);
 					if (cmdline != "zygote" && cmdline != "zygote64") {
 						executable_name = cmdline;
-						cached_bundle_id = cmdline.substring(0, cmdline.last_index_of (":"));
+						cached_bundle_id = cmdline[0:cmdline.last_index_of (":")];
 					}
 				} catch (FileError e) {
 				}

--- a/lib/gadget/gadget.vala
+++ b/lib/gadget/gadget.vala
@@ -304,6 +304,22 @@ namespace Frida.Gadget {
 				range: range
 			);
 		}
+
+#if ANDROID
+		construct {
+			if (executable_name.index_of ("app_process") >= 0) {
+				try {
+					string cmdline;
+					FileUtils.get_contents ("/proc/self/cmdline", out cmdline);
+					if (cmdline != "zygote" && cmdline != "zygote64") {
+						executable_name = cmdline;
+						cached_bundle_id = cmdline.substring(0, cmdline.last_index_of (":"));
+					}
+				} catch (FileError e) {
+				}
+			}
+		}
+#endif
 	}
 
 	private enum State {

--- a/lib/gadget/gadget.vala
+++ b/lib/gadget/gadget.vala
@@ -307,7 +307,7 @@ namespace Frida.Gadget {
 
 #if ANDROID
 		construct {
-			if (executable_name.index_of ("app_process") >= 0) {
+			if (executable_name.has_prefix ("app_process")) {
 				try {
 					string cmdline;
 					FileUtils.get_contents ("/proc/self/cmdline", out cmdline);


### PR DESCRIPTION
The executable name in gadget of android is always 'app_process32' or 'app_process64', and the bundle name is always null. So the feature of script optional configuration in ScriptDirectory mode is not work in android because of the filter will always not match.

I add additional  code for Android to retrieve real executable name and package name, and now android's gadget can work with script optional configuration such as below:

```
{
  "filter": {
     "executables": ["com.target.app:remote"]
  }
}
```

or like:

```
{
  "filter": {
     "bundles": ["com.target.app"]
  }
}
```