### PR TITLE
Add --parameters to frida-inject to allow specify parameters using a JSON string similar to frida-gadget

### DIFF
--- a/inject/inject.vala
+++ b/inject/inject.vala
@@ -74,7 +74,7 @@ namespace Frida.Inject {
 				parser.load_from_data (parameters_str, -1);
 				parameters.set_object (parser.get_root ().get_object ());
 			} catch (GLib.Error e) {
-				printerr ("Failed to parse parameters argument as JSON\n");
+				printerr ("Failed to parse parameters argument as JSON: %s\n", e.message);
 				return 5;
 			}
 		}

--- a/inject/inject.vala
+++ b/inject/inject.vala
@@ -64,13 +64,18 @@ namespace Frida.Inject {
 		var parameters = new Json.Node (Json.NodeType.OBJECT);
 		parameters.set_object (new Json.Object ()); 
 		if (parameters_str != null) {
+			if (parameters_str == "") {
+				printerr ("Parameters argument must be specified as JSON if present\n");
+				return 4;
+			}
+
 			try {
 				var parser = new Json.Parser ();
 				parser.load_from_data (parameters_str, -1);
 				parameters.set_object (parser.get_root ().get_object ());
 			} catch (GLib.Error e) {
 				printerr ("Failed to parse parameters argument as JSON\n");
-				return 4;
+				return 5;
 			}
 		}
 
@@ -132,7 +137,7 @@ namespace Frida.Inject {
 			construct;
 		}
 
-		public Json.Node? parameters {
+		public Json.Node parameters {
 			get;
 			construct;
 		}
@@ -154,7 +159,7 @@ namespace Frida.Inject {
 		private MainLoop loop;
 		private bool stopping;
 
-		public Application (int target_pid, string? target_name, string? script_path, string? script_source, Json.Node? parameters, bool enable_jit, bool enable_development) {
+		public Application (int target_pid, string? target_name, string? script_path, string? script_source, Json.Node parameters, bool enable_jit, bool enable_development) {
 			Object (
 				target_pid: target_pid,
 				target_name: target_name,
@@ -241,7 +246,7 @@ namespace Frida.Inject {
 		private Script script;
 		private string? script_path;
 		private string? script_source;
-		private Json.Node? parameters;
+		private Json.Node parameters;
 		private GLib.FileMonitor script_monitor;
 		private Source script_unchanged_timeout;
 		private RpcClient rpc_client;
@@ -249,7 +254,7 @@ namespace Frida.Inject {
 		private bool load_in_progress = false;
 		private bool enable_development = false;
 
-		public ScriptRunner (Session session, string? script_path, string? script_source, Json.Node? parameters, bool enable_jit, bool enable_development) {
+		public ScriptRunner (Session session, string? script_path, string? script_source, Json.Node parameters, bool enable_jit, bool enable_development) {
 			this.session = session;
 			this.script_path = script_path;
 			this.script_source = script_source;

--- a/inject/inject.vala
+++ b/inject/inject.vala
@@ -63,12 +63,14 @@ namespace Frida.Inject {
 
 		Json.Node parameters = new Json.Node (Json.NodeType.OBJECT);
 		parameters.set_object (new Json.Object ()); 
-		if (parameters_str != null && parameters_str != "") {
+		if (parameters_str != null) {
 			try {
 				var parser = new Json.Parser ();
 				parser.load_from_data (parameters_str, -1);
 				parameters.set_object (parser.get_root().get_object ());
 			} catch (GLib.Error e) {
+				printerr ("Failed to parse parameters argument as JSON\n");
+				return 4;
 			}
 		}
 

--- a/inject/inject.vala
+++ b/inject/inject.vala
@@ -14,7 +14,7 @@ namespace Frida.Inject {
 		{ "pid", 'p', 0, OptionArg.INT, ref target_pid, null, "PID" },
 		{ "name", 'n', 0, OptionArg.STRING, ref target_name, null, "PID" },
 		{ "script", 's', 0, OptionArg.FILENAME, ref script_path, null, "JAVASCRIPT_FILENAME" },
-		{ "parameters",  's', 0, OptionArg.STRING, ref parameters_str, "Parameters as JSON, same as Gadget", "PARAMETERS_JSON" },
+		{ "parameters",  'P', 0, OptionArg.STRING, ref parameters_str, "Parameters as JSON, same as Gadget", "PARAMETERS_JSON" },
 		{ "eternalize", 'e', 0, OptionArg.NONE, ref eternalize, "Eternalize script and exit", null },
 		{ "enable-jit", 0, 0, OptionArg.NONE, ref enable_jit, "Enable the JIT runtime", null },
 		{ "development", 'D', 0, OptionArg.NONE, ref enable_development, "Enable development mode", null },


### PR DESCRIPTION
My first Vala code, so it might not be vala-thonic

`./frida-inject -p 16920 --script test.js --parameters '{"paramBool": true, "paramArray": [1,2,3], "paramInt": 1, "paramStr": "str", "paramObj": {"a": ["b", "c", {}]}}'`

```
stage early
parameters {"paramBool":true,"paramArray":[1,2,3],"paramInt":1,"paramStr":"str","paramObj":{"a":["b","c",{}]}}
```