### PR TITLE
Added the 'map' right to the selinux frida_file configuration

### DIFF
--- a/lib/selinux/src/patch.c
+++ b/lib/selinux/src/patch.c
@@ -46,7 +46,7 @@ static const FridaSELinuxRule frida_selinux_rules[] =
   { { "domain", NULL }, "domain", "process", { "execmem", NULL } },
   { { "domain", NULL }, "frida_file", "dir", { "search", NULL } },
   { { "domain", NULL }, "frida_file", "fifo_file", { "open", "write", NULL } },
-  { { "domain", NULL }, "frida_file", "file", { "open", "read", "getattr", "execute", NULL } },
+  { { "domain", NULL }, "frida_file", "file", { "open", "read", "getattr", "execute", "map", NULL } },
   { { "domain", NULL }, "frida_file", "sock_file", { "write", NULL } },
   { { "domain", NULL }, "shell_data_file", "dir", { "search", NULL } },
   { { "domain", NULL }, "zygote_exec", "file", { "execute", NULL } },


### PR DESCRIPTION
Hi,

When trying to use Frida on a Samsung with Android 9, the **system_server** process dies when trying to launch the server with the following error:

`type=1400 audit(1570464586.875:837): avc:  denied  { map } for  pid=19050 comm="system_server" path="/system/priv-app/tmp_dir/frida-agent-64.so" dev="sda25" ino=5494 scontext=u:r:system_server:s0 tcontext=u:object_r:frida_file:s0 tclass=file permissive=0 audit_filtered`

So i just added the 'map' right to the selinux configuration of the **frida_file** context.
Tested and working on Samsung S10.