### PR TITLE
Keep eternalized entries alive

### DIFF
--- a/lib/agent/agent.vala
+++ b/lib/agent/agent.vala
@@ -616,6 +616,7 @@ namespace Frida.Agent {
 
 		private void on_script_eternalized (Gum.Script script) {
 			eternalized_scripts.add (script);
+			eternalized ();
 		}
 
 		private async void unload (Cancellable? cancellable) throws Error, IOError {

--- a/lib/interfaces/session.vala
+++ b/lib/interfaces/session.vala
@@ -37,6 +37,7 @@ namespace Frida {
 
 		public signal void opened (AgentSessionId id);
 		public signal void closed (AgentSessionId id);
+		public signal void eternalized ();
 		public signal void child_gating_changed (uint subscriber_count);
 	}
 


### PR DESCRIPTION
So that they can be reused for future connections to the same process, avoiding the need to have more than one agent, at least during the lifetime of frida-server.