### PR TITLE
Allow launchd agent to kill pending suspended processes on dispose

### DIFF
--- a/src/darwin/agent/launchd.js
+++ b/src/darwin/agent/launchd.js
@@ -5,13 +5,12 @@ var SIGKILL = 9;
 
 var upcoming = {};
 var gating = false;
+var suspendedPids = {};
 
 var jbdPidsToIgnore = null;
 
 var substrateInvocations = {};
 var substratePidsPending = {};
-
-var suspendedPids = {};
 
 rpc.exports = {
   dispose: function () {

--- a/src/darwin/agent/launchd.js
+++ b/src/darwin/agent/launchd.js
@@ -37,6 +37,9 @@ rpc.exports = {
   acknowledgeProcess: function (pid) {
     delete suspendedPids[pid];
   },
+  unacknowledgeProcess: function (pid) {
+    suspendedPids[pid] = pid;
+  },
 };
 
 applyJailbreakQuirks();

--- a/src/darwin/agent/launchd.js
+++ b/src/darwin/agent/launchd.js
@@ -34,10 +34,10 @@ rpc.exports = {
   disableSpawnGating: function () {
     gating = false;
   },
-  acknowledgeProcess: function (pid) {
+  claimProcess: function (pid) {
     delete suspendedPids[pid];
   },
-  unacknowledgeProcess: function (pid) {
+  unclaimProcess: function (pid) {
     suspendedPids[pid] = pid;
   },
 };

--- a/src/darwin/darwin-host-session.vala
+++ b/src/darwin/darwin-host-session.vala
@@ -573,6 +573,7 @@ namespace Frida {
 
 		private void on_spawn_captured (HostSpawnInfo info) {
 			xpcproxies.remove (info.pid);
+			launchd_agent.unacknowledge_process.begin (info.pid, io_cancellable);
 			handle_spawn.begin (info);
 		}
 
@@ -790,6 +791,10 @@ namespace Frida {
 
 		public async void acknowledge_process (uint pid, Cancellable? cancellable) throws Error, IOError {
 			yield call ("acknowledgeProcess", new Json.Node[] { new Json.Node.alloc ().init_int (pid) }, cancellable);
+		}
+
+		public async void unacknowledge_process (uint pid, Cancellable? cancellable) throws Error, IOError {
+			yield call ("unacknowledgeProcess", new Json.Node[] { new Json.Node.alloc ().init_int (pid) }, cancellable);
 		}
 
 		protected override void on_event (string type, Json.Array event) {

--- a/src/darwin/darwin-host-session.vala
+++ b/src/darwin/darwin-host-session.vala
@@ -380,8 +380,8 @@ namespace Frida {
 			launchd_agent.spawn_preparation_started.connect (on_spawn_preparation_started);
 			launchd_agent.spawn_preparation_aborted.connect (on_spawn_preparation_aborted);
 			launchd_agent.spawn_captured.connect (on_spawn_captured);
-			helper.resumed.connect (on_resumed);
-			helper.killed.connect (on_killed);
+			helper.process_resumed.connect (on_process_resumed);
+			helper.process_killed.connect (on_process_killed);
 		}
 
 		~FruitController () {
@@ -390,8 +390,8 @@ namespace Frida {
 			launchd_agent.spawn_preparation_started.disconnect (on_spawn_preparation_started);
 			launchd_agent.app_launch_completed.disconnect (on_app_launch_completed);
 			launchd_agent.app_launch_started.disconnect (on_app_launch_started);
-			helper.resumed.disconnect (on_resumed);
-			helper.killed.disconnect (on_killed);
+			helper.process_resumed.disconnect (on_process_resumed);
+			helper.process_killed.disconnect (on_process_killed);
 		}
 
 		public async void close (Cancellable? cancellable) throws IOError {
@@ -576,12 +576,12 @@ namespace Frida {
 			handle_spawn.begin (info);
 		}
 
-		private void on_resumed (uint pid) {
-			launchd_agent.forget_pid.begin (pid, io_cancellable);
+		private void on_process_resumed (uint pid) {
+			launchd_agent.acknowledge_process.begin (pid, io_cancellable);
 		}
 
-		private void on_killed (uint pid) {
-			launchd_agent.forget_pid.begin (pid, io_cancellable);
+		private void on_process_killed (uint pid) {
+			launchd_agent.acknowledge_process.begin (pid, io_cancellable);
 		}
 
 		private async void handle_spawn (HostSpawnInfo info) {
@@ -788,8 +788,8 @@ namespace Frida {
 			yield call ("disableSpawnGating", new Json.Node[] {}, cancellable);
 		}
 
-		public async void forget_pid (uint pid, Cancellable? cancellable) throws Error, IOError {
-			yield call ("forgetPid", new Json.Node[] { new Json.Node.alloc ().init_int (pid) }, cancellable);
+		public async void acknowledge_process (uint pid, Cancellable? cancellable) throws Error, IOError {
+			yield call ("acknowledgeProcess", new Json.Node[] { new Json.Node.alloc ().init_int (pid) }, cancellable);
 		}
 
 		protected override void on_event (string type, Json.Array event) {

--- a/src/darwin/darwin-host-session.vala
+++ b/src/darwin/darwin-host-session.vala
@@ -573,16 +573,16 @@ namespace Frida {
 
 		private void on_spawn_captured (HostSpawnInfo info) {
 			xpcproxies.remove (info.pid);
-			launchd_agent.unacknowledge_process.begin (info.pid, io_cancellable);
+			launchd_agent.unclaim_process.begin (info.pid, io_cancellable);
 			handle_spawn.begin (info);
 		}
 
 		private void on_process_resumed (uint pid) {
-			launchd_agent.acknowledge_process.begin (pid, io_cancellable);
+			launchd_agent.claim_process.begin (pid, io_cancellable);
 		}
 
 		private void on_process_killed (uint pid) {
-			launchd_agent.acknowledge_process.begin (pid, io_cancellable);
+			launchd_agent.claim_process.begin (pid, io_cancellable);
 		}
 
 		private async void handle_spawn (HostSpawnInfo info) {
@@ -789,12 +789,12 @@ namespace Frida {
 			yield call ("disableSpawnGating", new Json.Node[] {}, cancellable);
 		}
 
-		public async void acknowledge_process (uint pid, Cancellable? cancellable) throws Error, IOError {
-			yield call ("acknowledgeProcess", new Json.Node[] { new Json.Node.alloc ().init_int (pid) }, cancellable);
+		public async void claim_process (uint pid, Cancellable? cancellable) throws Error, IOError {
+			yield call ("claimProcess", new Json.Node[] { new Json.Node.alloc ().init_int (pid) }, cancellable);
 		}
 
-		public async void unacknowledge_process (uint pid, Cancellable? cancellable) throws Error, IOError {
-			yield call ("unacknowledgeProcess", new Json.Node[] { new Json.Node.alloc ().init_int (pid) }, cancellable);
+		public async void unclaim_process (uint pid, Cancellable? cancellable) throws Error, IOError {
+			yield call ("unclaimProcess", new Json.Node[] { new Json.Node.alloc ().init_int (pid) }, cancellable);
 		}
 
 		protected override void on_event (string type, Json.Array event) {

--- a/src/darwin/frida-helper-backend.vala
+++ b/src/darwin/frida-helper-backend.vala
@@ -307,18 +307,18 @@ namespace Frida {
 				_resume_process (borrow_task_for_remote_pid (pid));
 			}
 
-			resumed (pid);
+			process_resumed (pid);
 		}
 
 		public async void kill_process (uint pid, Cancellable? cancellable) throws Error, IOError {
 			_kill_process (pid);
-			killed (pid);
+			process_killed (pid);
 		}
 
 		public async void kill_application (string identifier, Cancellable? cancellable) throws Error, IOError {
 			var killed_pid = _kill_application (identifier);
 			if (killed_pid > 0)
-				killed (killed_pid);
+				process_killed (killed_pid);
 		}
 
 		public async uint inject_library_file (uint pid, string path, string entrypoint, string data, Cancellable? cancellable)

--- a/src/darwin/frida-helper-backend.vala
+++ b/src/darwin/frida-helper-backend.vala
@@ -306,14 +306,19 @@ namespace Frida {
 			} else {
 				_resume_process (borrow_task_for_remote_pid (pid));
 			}
+
+			resumed (pid);
 		}
 
 		public async void kill_process (uint pid, Cancellable? cancellable) throws Error, IOError {
 			_kill_process (pid);
+			killed (pid);
 		}
 
 		public async void kill_application (string identifier, Cancellable? cancellable) throws Error, IOError {
-			_kill_application (identifier);
+			var killed_pid = _kill_application (identifier);
+			if (killed_pid > 0)
+				killed (killed_pid);
 		}
 
 		public async uint inject_library_file (uint pid, string path, string entrypoint, string data, Cancellable? cancellable)
@@ -600,7 +605,7 @@ namespace Frida {
 		protected extern void _resume_process (uint task) throws Error;
 		protected extern void _resume_process_fast (uint task) throws Error;
 		protected extern static void _kill_process (uint pid);
-		protected extern static void _kill_application (string identifier);
+		protected extern static uint _kill_application (string identifier);
 		public extern static bool is_application_process (uint pid);
 		protected extern void * _create_spawn_instance (uint pid);
 		protected extern void _prepare_spawn_instance_for_injection (void * instance, uint task) throws Error;

--- a/src/darwin/frida-helper-process.vala
+++ b/src/darwin/frida-helper-process.vala
@@ -296,8 +296,8 @@ namespace Frida {
 				proxy.spawn_removed.connect (on_spawn_removed);
 				proxy.injected.connect (on_injected);
 				proxy.uninjected.connect (on_uninjected);
-				proxy.resumed.connect (on_resumed);
-				proxy.killed.connect (on_killed);
+				proxy.process_resumed.connect (on_process_resumed);
+				proxy.process_killed.connect (on_process_killed);
 
 				obtain_request.resolve (proxy);
 				return proxy;
@@ -331,8 +331,8 @@ namespace Frida {
 			proxy.spawn_removed.disconnect (on_spawn_removed);
 			proxy.injected.disconnect (on_injected);
 			proxy.uninjected.disconnect (on_uninjected);
-			proxy.resumed.disconnect (on_resumed);
-			proxy.killed.disconnect (on_killed);
+			proxy.process_resumed.disconnect (on_process_resumed);
+			proxy.process_killed.disconnect (on_process_killed);
 			proxy = null;
 
 			connection.on_closed.disconnect (on_connection_closed);
@@ -362,12 +362,12 @@ namespace Frida {
 			uninjected (id);
 		}
 
-		private void on_resumed (uint pid) {
-			resumed (pid);
+		private void on_process_resumed (uint pid) {
+			process_resumed (pid);
 		}
 
-		private void on_killed (uint pid) {
-			killed (pid);
+		private void on_process_killed (uint pid) {
+			process_killed (pid);
 		}
 	}
 

--- a/src/darwin/frida-helper-process.vala
+++ b/src/darwin/frida-helper-process.vala
@@ -296,6 +296,8 @@ namespace Frida {
 				proxy.spawn_removed.connect (on_spawn_removed);
 				proxy.injected.connect (on_injected);
 				proxy.uninjected.connect (on_uninjected);
+				proxy.resumed.connect (on_resumed);
+				proxy.killed.connect (on_killed);
 
 				obtain_request.resolve (proxy);
 				return proxy;
@@ -329,6 +331,8 @@ namespace Frida {
 			proxy.spawn_removed.disconnect (on_spawn_removed);
 			proxy.injected.disconnect (on_injected);
 			proxy.uninjected.disconnect (on_uninjected);
+			proxy.resumed.disconnect (on_resumed);
+			proxy.killed.disconnect (on_killed);
 			proxy = null;
 
 			connection.on_closed.disconnect (on_connection_closed);
@@ -356,6 +360,14 @@ namespace Frida {
 
 		private void on_uninjected (uint id) {
 			uninjected (id);
+		}
+
+		private void on_resumed (uint pid) {
+			resumed (pid);
+		}
+
+		private void on_killed (uint pid) {
+			killed (pid);
 		}
 	}
 

--- a/src/darwin/frida-helper-service.vala
+++ b/src/darwin/frida-helper-service.vala
@@ -49,6 +49,8 @@ namespace Frida {
 			backend.spawn_removed.connect (on_backend_spawn_removed);
 			backend.injected.connect (on_backend_injected);
 			backend.uninjected.connect (on_backend_uninjected);
+			backend.resumed.connect (on_backend_resumed);
+			backend.killed.connect (on_backend_killed);
 		}
 
 		public int run () {
@@ -96,6 +98,8 @@ namespace Frida {
 			backend.spawn_removed.disconnect (on_backend_spawn_removed);
 			backend.injected.disconnect (on_backend_injected);
 			backend.uninjected.disconnect (on_backend_uninjected);
+			backend.resumed.disconnect (on_backend_resumed);
+			backend.killed.disconnect (on_backend_killed);
 			backend = null;
 
 			shutdown_request.resolve (true);
@@ -238,6 +242,14 @@ namespace Frida {
 
 		private void on_backend_uninjected (uint id) {
 			uninjected (id);
+		}
+
+		private void on_backend_resumed (uint pid) {
+			resumed (pid);
+		}
+
+		private void on_backend_killed (uint pid) {
+			killed (pid);
 		}
 	}
 }

--- a/src/darwin/frida-helper-service.vala
+++ b/src/darwin/frida-helper-service.vala
@@ -49,8 +49,8 @@ namespace Frida {
 			backend.spawn_removed.connect (on_backend_spawn_removed);
 			backend.injected.connect (on_backend_injected);
 			backend.uninjected.connect (on_backend_uninjected);
-			backend.resumed.connect (on_backend_resumed);
-			backend.killed.connect (on_backend_killed);
+			backend.process_resumed.connect (on_backend_process_resumed);
+			backend.process_killed.connect (on_backend_process_killed);
 		}
 
 		public int run () {
@@ -98,8 +98,8 @@ namespace Frida {
 			backend.spawn_removed.disconnect (on_backend_spawn_removed);
 			backend.injected.disconnect (on_backend_injected);
 			backend.uninjected.disconnect (on_backend_uninjected);
-			backend.resumed.disconnect (on_backend_resumed);
-			backend.killed.disconnect (on_backend_killed);
+			backend.process_resumed.disconnect (on_backend_process_resumed);
+			backend.process_killed.disconnect (on_backend_process_killed);
 			backend = null;
 
 			shutdown_request.resolve (true);
@@ -244,12 +244,12 @@ namespace Frida {
 			uninjected (id);
 		}
 
-		private void on_backend_resumed (uint pid) {
-			resumed (pid);
+		private void on_backend_process_resumed (uint pid) {
+			process_resumed (pid);
 		}
 
-		private void on_backend_killed (uint pid) {
-			killed (pid);
+		private void on_backend_process_killed (uint pid) {
+			process_killed (pid);
 		}
 	}
 }

--- a/src/darwin/frida-helper-types.vala
+++ b/src/darwin/frida-helper-types.vala
@@ -5,8 +5,8 @@ namespace Frida {
 		public signal void spawn_removed (HostSpawnInfo info);
 		public signal void injected (uint id, uint pid, bool has_mapped_module, DarwinModuleDetails mapped_module);
 		public signal void uninjected (uint id);
-		public signal void resumed (uint pid);
-		public signal void killed (uint pid);
+		public signal void process_resumed (uint pid);
+		public signal void process_killed (uint pid);
 
 		public abstract uint pid {
 			get;
@@ -52,8 +52,8 @@ namespace Frida {
 		public signal void spawn_removed (HostSpawnInfo info);
 		public signal void injected (uint id, uint pid, bool has_mapped_module, DarwinModuleDetails mapped_module);
 		public signal void uninjected (uint id);
-		public signal void resumed (uint pid);
-		public signal void killed (uint pid);
+		public signal void process_resumed (uint pid);
+		public signal void process_killed (uint pid);
 
 		public abstract async void stop (Cancellable? cancellable) throws GLib.Error;
 

--- a/src/darwin/frida-helper-types.vala
+++ b/src/darwin/frida-helper-types.vala
@@ -5,6 +5,8 @@ namespace Frida {
 		public signal void spawn_removed (HostSpawnInfo info);
 		public signal void injected (uint id, uint pid, bool has_mapped_module, DarwinModuleDetails mapped_module);
 		public signal void uninjected (uint id);
+		public signal void resumed (uint pid);
+		public signal void killed (uint pid);
 
 		public abstract uint pid {
 			get;
@@ -50,6 +52,8 @@ namespace Frida {
 		public signal void spawn_removed (HostSpawnInfo info);
 		public signal void injected (uint id, uint pid, bool has_mapped_module, DarwinModuleDetails mapped_module);
 		public signal void uninjected (uint id);
+		public signal void resumed (uint pid);
+		public signal void killed (uint pid);
 
 		public abstract async void stop (Cancellable? cancellable) throws GLib.Error;
 


### PR DESCRIPTION
In this way if frida-server dies it doesn’t leave back unattended pending spawns in a suspended state.