### PR TITLE
Support both cleartext and encrypted lockdown channels

### DIFF
--- a/src/fruity/dtx.vala
+++ b/src/fruity/dtx.vala
@@ -388,7 +388,7 @@ namespace Frida.Fruity {
 			connections[channel_provider] = request.future;
 
 			try {
-				var stream = yield channel_provider.open_channel ("lockdown:com.apple.instruments.remoteserver",
+				var stream = yield channel_provider.open_channel ("lockdown:com.apple.instruments.remoteserver?tls=handshake-only",
 					cancellable);
 
 				var connection = new DTXConnection (stream);

--- a/src/fruity/fruity-host-session.vala
+++ b/src/fruity/fruity-host-session.vala
@@ -296,14 +296,23 @@ namespace Frida {
 			if (address.has_prefix ("lockdown:")) {
 				string service_name = address.substring (9);
 
-				var client = yield get_lockdown_client (cancellable);
+				if (service_name.length != 0) {
+					var client = yield get_lockdown_client (cancellable);
 
-				try {
-					return yield client.start_service (service_name, cancellable);
-				} catch (GLib.Error e) {
-					if (e is Fruity.LockdownError.INVALID_SERVICE)
+					try {
+						return yield client.start_service (service_name, cancellable);
+					} catch (GLib.Error e) {
+						if (e is Fruity.LockdownError.INVALID_SERVICE)
+							throw new Error.NOT_SUPPORTED ("%s", e.message);
+						throw new Error.TRANSPORT ("%s", e.message);
+					}
+				} else {
+					try {
+						var client = yield Fruity.LockdownClient.open (device_details, cancellable);
+						return client.stream;
+					} catch (GLib.Error e) {
 						throw new Error.NOT_SUPPORTED ("%s", e.message);
-					throw new Error.TRANSPORT ("%s", e.message);
+					}
 				}
 			}
 

--- a/src/fruity/lockdown.vala
+++ b/src/fruity/lockdown.vala
@@ -7,8 +7,11 @@ namespace Frida.Fruity {
 			construct;
 		}
 
-		private PlistServiceClient service;
+		public IOStream stream {
+			get { return service.stream; }
+		}
 
+		private PlistServiceClient service;
 		private string host_id;
 		private string system_buid;
 		private TlsCertificate tls_certificate;


### PR DESCRIPTION
By default the channel is encrypted, unless the service name includes the “?tls=handshake-only” suffix. Internally, the “com.apple.debugserver” and “com.apple.instruments.remoteserver” channels are kept cleartext.