### PR TITLE
Fixed #269: Parent file descriptors not available in child process 

### DIFF
--- a/src/darwin/frida-helper-backend-glue.m
+++ b/src/darwin/frida-helper-backend-glue.m
@@ -633,7 +633,7 @@ _frida_darwin_helper_backend_spawn (FridaDarwinHelperBackend * self, const gchar
   sigemptyset (&signal_mask_set);
   posix_spawnattr_setsigmask (&attributes, &signal_mask_set);
 
-  flags = POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_CLOEXEC_DEFAULT | POSIX_SPAWN_START_SUSPENDED;
+  flags = POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_START_SUSPENDED;
 
   stdio = frida_host_spawn_options_get_stdio (options);
   switch (stdio)

--- a/src/darwin/frida-helper-process.vala
+++ b/src/darwin/frida-helper-process.vala
@@ -267,7 +267,7 @@ namespace Frida {
 				var handshake_port = new HandshakePort.local (service_name);
 
 				string[] argv = { get_resource_store ().helper.path, service_name };
-				pending_process = new Subprocess.newv (argv, SubprocessFlags.STDIN_INHERIT);
+				pending_process = new Subprocess.newv (argv, SubprocessFlags.INHERIT_FDS);
 
 				var peer_pid = (uint) uint64.parse (pending_process.get_identifier ());
 				IOStream stream;


### PR DESCRIPTION
Modified the flags for when a new process for target and helper is started. 
This way FDs opened by parent are not lost. This only affect MacOS (darwin).
Check [issue](https://github.com/frida/frida-core/issues/269) for additional details.