### PR TITLE
Fixes #301 usbmux pair record plist parsing

### DIFF
--- a/src/fruity/plist.vala
+++ b/src/fruity/plist.vala
@@ -1,36 +1,37 @@
 namespace Frida.Fruity {
 	public class Plist : PlistDict {
-		public const uint8 FMT_AUTO = 0;
-		public const uint8 FMT_BIN = 1;
-		public const uint8 FMT_XML = 2;
+		public enum Format {
+			AUTO,
+			BINARY,
+			XML
+		}
 		private const int64 MAC_EPOCH_DELTA_FROM_UNIX = 978307200LL;
 
 		public Plist.from_binary (uint8[] data) throws PlistError {
-			this.from_data (data, FMT_BIN);
+			this.from_data (data, BINARY);
 		}
 
 		public Plist.from_xml (string xml) throws PlistError {
-			this.from_data (xml.data, FMT_XML);
+			this.from_data (xml.data, XML);
 		}
 
-		public Plist.from_data (uint8[] data, uint8 fmt=FMT_AUTO) throws PlistError {
-			if (fmt == FMT_AUTO) {
+		public Plist.from_data (uint8[] data, Format fmt = AUTO) throws PlistError {
+			if (fmt == AUTO) {
 				unowned string magic = (string) data;
 				if (magic.has_prefix ("bplist")) {
-					fmt = FMT_BIN;
+					fmt = BINARY;
 				} else {
-					// assume XML
-					fmt = FMT_XML;
+					fmt = XML;
 				}
 			}
-			if (fmt == FMT_BIN) {
+			if (fmt == BINARY) {
 				var parser = new BinaryParser (this);
 				parser.parse (data);
-			} else if (fmt == FMT_XML) {
+			} else if (fmt == XML) {
 				var parser = new XmlParser (this);
-				parser.parse ((string)data);
+				parser.parse ((string) data);
 			} else {
-				throw new PlistError.INVALID_DATA ("Invalid format specified: %d", fmt);
+				assert_not_reached ();
 			}
 		}
 

--- a/src/fruity/plist.vala
+++ b/src/fruity/plist.vala
@@ -5,6 +5,7 @@ namespace Frida.Fruity {
 			BINARY,
 			XML
 		}
+
 		private const int64 MAC_EPOCH_DELTA_FROM_UNIX = 978307200LL;
 
 		public Plist.from_binary (uint8[] data) throws PlistError {
@@ -15,19 +16,19 @@ namespace Frida.Fruity {
 			this.from_data (xml.data, XML);
 		}
 
-		public Plist.from_data (uint8[] data, Format fmt = AUTO) throws PlistError {
-			if (fmt == AUTO) {
+		public Plist.from_data (uint8[] data, Format format = AUTO) throws PlistError {
+			if (format == AUTO) {
 				unowned string magic = (string) data;
 				if (magic.has_prefix ("bplist")) {
-					fmt = BINARY;
+					format = BINARY;
 				} else {
-					fmt = XML;
+					format = XML;
 				}
 			}
-			if (fmt == BINARY) {
+			if (format == BINARY) {
 				var parser = new BinaryParser (this);
 				parser.parse (data);
-			} else if (fmt == XML) {
+			} else if (format == XML) {
 				var parser = new XmlParser (this);
 				parser.parse ((string) data);
 			} else {

--- a/src/fruity/usbmux.vala
+++ b/src/fruity/usbmux.vala
@@ -154,9 +154,8 @@ namespace Frida.Fruity {
 				}
 
 				var raw_record = response.get_bytes ("PairRecordData");
-				unowned string record_xml_unterminated = (string) raw_record.get_data ();
-				string record_xml = record_xml_unterminated[0:raw_record.length];
-				return new Plist.from_xml (record_xml);
+				var record_data = raw_record.get_data ();
+				return new Plist.from_data (record_data);
 			} catch (PlistError e) {
 				throw new UsbmuxError.PROTOCOL ("Unexpected response: %s", e.message);
 			}

--- a/src/fruity/usbmux.vala
+++ b/src/fruity/usbmux.vala
@@ -154,8 +154,7 @@ namespace Frida.Fruity {
 				}
 
 				var raw_record = response.get_bytes ("PairRecordData");
-				var record_data = raw_record.get_data ();
-				return new Plist.from_data (record_data);
+				return new Plist.from_data (raw_record.get_data ());
 			} catch (PlistError e) {
 				throw new UsbmuxError.PROTOCOL ("Unexpected response: %s", e.message);
 			}


### PR DESCRIPTION
* added Plist.from_data to support auto-detecting plist format.
* UsbmuxClient.read_pair_record() supports auto-detecting plist format