### PR TITLE
Relaxed post restriction in LOADING state

### DIFF
--- a/lib/payload/script-engine.vala
+++ b/lib/payload/script-engine.vala
@@ -436,7 +436,7 @@ namespace Frida {
 					case LOADING:
 					case LOADED:
 					case DISPOSED:
-					throw new Error.INVALID_OPERATION ("Only scripts still alive may be posted to");
+						throw new Error.INVALID_OPERATION ("Only active scripts may be posted to");
 					default:
 						script.post (message, data);
 						break;

--- a/lib/payload/script-engine.vala
+++ b/lib/payload/script-engine.vala
@@ -432,10 +432,15 @@ namespace Frida {
 			}
 
 			public void post (string message, Bytes? data) throws Error {
-				if (state != LOADED && state != DISPOSED && state != LOADING)
-					throw new Error.INVALID_OPERATION ("Only loading/loaded scripts may be posted to");
-
-				script.post (message, data);
+				switch(state) {
+					case LOADING:
+					case LOADED:
+					case DISPOSED:
+					throw new Error.INVALID_OPERATION ("Only scripts still alive may be posted to");
+					default:
+					script.post (message, data);
+					break;
+				}
 			}
 
 			private void on_message (Gum.Script script, string raw_message, Bytes? data) {

--- a/lib/payload/script-engine.vala
+++ b/lib/payload/script-engine.vala
@@ -438,8 +438,8 @@ namespace Frida {
 					case DISPOSED:
 					throw new Error.INVALID_OPERATION ("Only scripts still alive may be posted to");
 					default:
-					script.post (message, data);
-					break;
+						script.post (message, data);
+						break;
 				}
 			}
 

--- a/lib/payload/script-engine.vala
+++ b/lib/payload/script-engine.vala
@@ -432,8 +432,8 @@ namespace Frida {
 			}
 
 			public void post (string message, Bytes? data) throws Error {
-				if (state != LOADED && state != DISPOSED)
-					throw new Error.INVALID_OPERATION ("Only loaded scripts may be posted to");
+				if (state != LOADED && state != DISPOSED && state != LOADING)
+					throw new Error.INVALID_OPERATION ("Only loading/loaded scripts may be posted to");
 
 				script.post (message, data);
 			}

--- a/lib/payload/script-engine.vala
+++ b/lib/payload/script-engine.vala
@@ -432,7 +432,7 @@ namespace Frida {
 			}
 
 			public void post (string message, Bytes? data) throws Error {
-				switch(state) {
+				switch (state) {
 					case LOADING:
 					case LOADED:
 					case DISPOSED:


### PR DESCRIPTION
Scripts in the LOADING state currently are unable to have messages posted to them. This makes scripts unable to use blocking `recv()` while in their main body. This restriction is unnecessary as LOADING scripts are perfectly capable of receiving messages.

Tested and working with blocking `recv()` in local build.

Fix to issue: https://github.com/frida/frida-gum/issues/420