### PR TITLE
Added the ability to run frida-server on a non-root Android device.

### DIFF
--- a/lib/pipe/pipe-unix.c
+++ b/lib/pipe/pipe-unix.c
@@ -27,7 +27,23 @@ frida_pipe_transport_get_temp_directory (void)
   if (temp_directory != NULL)
     return temp_directory;
   else
+  {
+    char buf[512];
+    FILE *fp=NULL;
+    char *bufp;
+    
+    fp = fopen("fridakeep","r");
+    if(fp)
+    {
+      if((bufp = fgets(buf, sizeof buf - 1, fp)) != NULL)
+      {
+        fclose(fp);
+        bufp[strlen(bufp)-1]='\0';
+        return bufp;
+      }
+    }
     return FRIDA_TEMP_PATH;
+  }
 }
 
 void

--- a/lib/selinux/src/patch.c
+++ b/lib/selinux/src/patch.c
@@ -63,6 +63,11 @@ G_DEFINE_QUARK (frida-selinux-error-quark, frida_selinux_error)
 void
 frida_selinux_apply_policy_patch (void)
 {
+#ifdef HAVE_ANDROID
+  if(access("fridakeep",F_OK ) != -1 ) {
+    return;
+  } 
+#endif
   const gchar * system_policy = "/sys/fs/selinux/policy";
   policydb_t db;
   gchar * db_data;

--- a/src/linux/system-linux.c
+++ b/src/linux/system-linux.c
@@ -182,6 +182,20 @@ gchar *
 frida_temporary_directory_get_system_tmp (void)
 {
 #ifdef HAVE_ANDROID
+  char buf[512];
+  FILE *fp=NULL;
+  char *bufp;
+
+  fp = fopen("fridakeep","r");
+  if(fp)
+  {
+    if((bufp = fgets(buf, sizeof buf - 1, fp)) != NULL)
+    {
+      fclose(fp);
+      bufp[strlen(bufp)-1]='\0';
+      return g_strdup(bufp);
+    }
+  }
   if (getuid () == 0)
     return g_strdup ("/data/local/tmp");
 #endif


### PR DESCRIPTION
I've made some fixes to make frida-server work on non-root terminals.
If a file named "fridakeep" exists in the same directory as frida-server, the following is applied.

1.disabling selinux checks
2.On Android, change the default "/data/local/tmp" to the path described in fridakeep.
```
/data/data/com.app.name
```
As with frida-gadget, some advance preparation is required.
1.APK:AndroidManifest.xml in android:debuggable="true"
2.command
```
$ adb shell
$ pm list packages
$ run-as com.app.name
$ cp /data/local/tmp/frida-server ./frida-server
$ ./frida-server
```
I hope that this fix will contribute to the development of security diagnostics.