### PR TITLE
Remove tcp check in android open_channel so that other protocols are supported

### DIFF
--- a/src/droidy/droidy-host-session.vala
+++ b/src/droidy/droidy-host-session.vala
@@ -230,7 +230,7 @@ namespace Frida {
 		}
 
 		public async IOStream open_channel (string address, Cancellable? cancellable = null) throws Error, IOError {
-			if (address.split(":").length == 2) {
+			if (address.contains (":")) {
 				Droidy.Client client = null;
 				try {
 					client = yield Droidy.Client.open (cancellable);

--- a/src/droidy/droidy-host-session.vala
+++ b/src/droidy/droidy-host-session.vala
@@ -230,11 +230,7 @@ namespace Frida {
 		}
 
 		public async IOStream open_channel (string address, Cancellable? cancellable = null) throws Error, IOError {
-			string[] protocols = {"tcp", "localabstract", "localreserved", "localfilesystem", "dev", "jdwp"};
-
-			string[] address_parts = address.split(":");
-			if (address_parts.length == 2 && address_parts[0] in protocols) {
-
+			if (address.split(":").length == 2) {
 				Droidy.Client client = null;
 				try {
 					client = yield Droidy.Client.open (cancellable);


### PR DESCRIPTION
This small change just removes the check for the "tcp:" prefix in open_channel so that other protocols like localabstract, localreserved, etc will work. Droidy.Client.request_protocol_change already handles this appropriately. Now the only check is that the address has the format "%s:%s".