### PR TITLE
Added non-root mode to frida-server in android.

### DIFF
--- a/lib/selinux/src/patch.c
+++ b/lib/selinux/src/patch.c
@@ -63,6 +63,13 @@ G_DEFINE_QUARK (frida-selinux-error-quark, frida_selinux_error)
 void
 frida_selinux_apply_policy_patch (void)
 {
+#ifdef HAVE_ANDROID
+  if(getuid()!=0)
+  {
+    g_print("Start frida-server in non-root mode. Some functions are limited.\n");
+    return;
+  }
+#endif
   const gchar * system_policy = "/sys/fs/selinux/policy";
   policydb_t db;
   gchar * db_data;

--- a/src/linux/system-linux.c
+++ b/src/linux/system-linux.c
@@ -184,6 +184,8 @@ frida_temporary_directory_get_system_tmp (void)
 #ifdef HAVE_ANDROID
   if (getuid () == 0)
     return g_strdup ("/data/local/tmp");
+  else
+    return g_strdup("");
 #endif
 
   return g_strdup (g_get_tmp_dir ());


### PR DESCRIPTION
On Android, frida-server works on non-root device.
When frida-server is run by non-root user, the following is applied.

1.disable selinux check
2.change /data/local/tmp to the same directory as frida-server.

To make it understandable to the user, it displays the following when running in non-root mode
「Start frida-server in non-root mode. Some functions are limited.」

As with frida-gadget, some advance preparation is required.
1.APK:AndroidManifest.xml in android:debuggable="true"
2.command

$ adb shell
$ pm list packages
$ run-as com.app.name
$ cp /data/local/tmp/frida-server frida-server
$ ./frida-server
