### PR TITLE
Fix initial device list logic on fruity host session

### DIFF
--- a/src/fruity/fruity-host-session.vala
+++ b/src/fruity/fruity-host-session.vala
@@ -47,6 +47,7 @@ namespace Frida {
 		private async void do_start () {
 			bool success = true;
 			Fruity.DeviceId[] initial_device_ids = {};
+			Fruity.UsbmuxClient list_client = null;
 
 			try {
 				control_client = yield Fruity.UsbmuxClient.open (start_cancellable);
@@ -58,10 +59,16 @@ namespace Frida {
 					remove_device (id);
 				});
 
-				initial_device_ids = yield control_client.list_devices (start_cancellable);
 				yield control_client.enable_listen_mode (start_cancellable);
+
+				list_client = yield Fruity.UsbmuxClient.open (start_cancellable);
+				initial_device_ids = yield list_client.list_devices (start_cancellable);
 			} catch (GLib.Error e) {
 				success = false;
+			}
+
+			if (list_client != null) {
+				list_client.close.begin (null);
 			}
 
 			if (success) {
@@ -78,7 +85,7 @@ namespace Frida {
 							remove_device (id);
 						}
 
-						yield validate_client.close (null);
+						validate_client.close.begin (null);
 					}
 				} catch (GLib.Error e) {
 					success = false;


### PR DESCRIPTION
usbmuxd doesn't accept any command after starting the listening mode. The “dummy request” we used to flush the device list makes usbmuxd [close the connection](https://github.com/libimobiledevice/usbmuxd/blob/master/src/client.c#L655) because the command is received in the wrong state.

To avoid this while ensuring the initial device list is as close as possible to the actual set of connected devices, the new logic is:
- call ListDevices
- start listening for changes in the list
- try to connect to all devices in the initial list, to
ensure they’ve not been detached in the meantime
- remove detached devices from the list