### PR TITLE
Handle control_client closed by usbmuxd

### DIFF
--- a/src/fruity/fruity-host-session.vala
+++ b/src/fruity/fruity-host-session.vala
@@ -48,13 +48,13 @@ namespace Frida {
 			bool success = yield try_start_control_connection ();
 
 			if (success) {
-				/* perform a dummy-request to flush out any pending device attach notifications */
+				/* Perform a dummy-request to flush out any pending device attach notifications. */
 				try {
 					yield control_client.connect_to_port (Fruity.DeviceId (uint.MAX), 0, start_cancellable);
 					assert_not_reached ();
 				} catch (GLib.Error expected_error) {
 					if (expected_error.code == IOError.CONNECTION_CLOSED) {
-						/* usbmuxd closes the connection when receiving commands in the wrong state */
+						/* Deal with usbmuxd closing the connection when receiving commands in the wrong state. */
 						control_client.close.begin (null);
 
 						success = yield try_start_control_connection ();
@@ -63,7 +63,9 @@ namespace Frida {
 							try {
 								flush_client = yield Fruity.UsbmuxClient.open (start_cancellable);
 								try {
-									yield flush_client.connect_to_port (Fruity.DeviceId (uint.MAX), 0, start_cancellable);
+									yield flush_client.connect_to_port (
+											Fruity.DeviceId (uint.MAX), 0,
+											start_cancellable);
 									assert_not_reached ();
 								} catch (GLib.Error expected_error) {
 								}
@@ -74,7 +76,7 @@ namespace Frida {
 							if (flush_client != null)
 								flush_client.close.begin (null);
 
-							if (success == false && control_client != null) {
+							if (!success && control_client != null) {
 								control_client.close.begin (null);
 								control_client = null;
 							}

--- a/src/fruity/fruity-host-session.vala
+++ b/src/fruity/fruity-host-session.vala
@@ -45,6 +45,51 @@ namespace Frida {
 		}
 
 		private async void do_start () {
+			bool success = yield try_start_control_connection ();
+
+			if (success) {
+				/* perform a dummy-request to flush out any pending device attach notifications */
+				try {
+					yield control_client.connect_to_port (Fruity.DeviceId (uint.MAX), 0, start_cancellable);
+					assert_not_reached ();
+				} catch (GLib.Error expected_error) {
+					if (expected_error.code == IOError.CONNECTION_CLOSED) {
+						/* usbmuxd closes the connection when receiving commands in the wrong state */
+						control_client.close.begin (null);
+
+						success = yield try_start_control_connection ();
+						if (success) {
+							Fruity.UsbmuxClient flush_client = null;
+							try {
+								flush_client = yield Fruity.UsbmuxClient.open (start_cancellable);
+								try {
+									yield flush_client.connect_to_port (Fruity.DeviceId (uint.MAX), 0, start_cancellable);
+									assert_not_reached ();
+								} catch (GLib.Error expected_error) {
+								}
+							} catch (GLib.Error e) {
+								success = false;
+							}
+
+							if (flush_client != null)
+								flush_client.close.begin (null);
+
+							if (success == false && control_client != null) {
+								control_client.close.begin (null);
+								control_client = null;
+							}
+						}
+					}
+				}
+			}
+
+			start_request.resolve (success);
+
+			if (on_start_completed != null)
+				on_start_completed ();
+		}
+
+		private async bool try_start_control_connection () {
 			bool success = true;
 
 			try {
@@ -61,23 +106,13 @@ namespace Frida {
 			} catch (GLib.Error e) {
 				success = false;
 			}
-
-			if (success) {
-				/* perform a dummy-request to flush out any pending device attach notifications */
-				try {
-					yield control_client.connect_to_port (Fruity.DeviceId (uint.MAX), 0, start_cancellable);
-					assert_not_reached ();
-				} catch (GLib.Error expected_error) {
-				}
-			} else if (control_client != null) {
+						  
+			if (!success && control_client != null) {
 				control_client.close.begin (null);
 				control_client = null;
 			}
 
-			start_request.resolve (success);
-
-			if (on_start_completed != null)
-				on_start_completed ();
+			return success;
 		}
 
 		public async void stop (Cancellable? cancellable) throws IOError {


### PR DESCRIPTION
This is an alternative simpler solution for the same problem https://github.com/frida/frida-core/pull/329 was attempting to solve.

usbmuxd doesn’t accept any command after starting the listening mode. The “dummy request” we used to flush the device list makes usbmuxd close the connection because the command is received in the wrong state.

To avoid this issue, the new logic is:

- detect if the peer has closed the connection
- in that case reopen it, and send the “dummy
request” on a secondary connection

That should work because usbmuxd handles all clients on a single thread, so by the time the “dummy request” is handled, the entire list of currently connected devices should have been sent.

According to my local tests, performance-wise this is indistinguishable from the previous logic.