### PR TITLE
Fix starting Android activities when the intent is not automatically found

### DIFF
--- a/src/linux/agent/system-server.js
+++ b/src/linux/agent/system-server.js
@@ -1,4 +1,4 @@
-var ApplicationInfo, ComponentName, ContextWrapper, Intent, RunningAppProcessInfo, RunningTaskInfo, UserHandle, GET_META_DATA, GET_ACTIVITIES;
+var ApplicationInfo, ComponentName, ContextWrapper, Intent, RunningAppProcessInfo, RunningTaskInfo, UserHandle, GET_META_DATA, GET_ACTIVITIES, FLAG_ACTIVITY_NEW_TASK;
 var context, packageManager, activityManager;
 
 var multiUserSupported;
@@ -19,6 +19,7 @@ function init() {
   var ACTIVITY_SERVICE = Context.ACTIVITY_SERVICE.value;
   GET_META_DATA = PackageManager.GET_META_DATA.value;
   GET_ACTIVITIES = PackageManager.GET_ACTIVITIES.value;
+  FLAG_ACTIVITY_NEW_TASK = Intent.FLAG_ACTIVITY_NEW_TASK.value;
 
   multiUserSupported = 'getApplicationInfoAsUser' in PackageManager;
 
@@ -130,7 +131,7 @@ rpc.exports = {
 
       if (intent === null) {
         intent = Intent.$new();
-        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK.value);
+        intent.setFlags(FLAG_ACTIVITY_NEW_TASK);
       }
 
       if (activity !== null) {

--- a/src/linux/agent/system-server.js
+++ b/src/linux/agent/system-server.js
@@ -130,7 +130,7 @@ rpc.exports = {
 
       if (intent === null) {
         intent = Intent.$new();
-        intent.setAction('android.intent.action.MAIN');
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK.value);
       }
 
       if (activity !== null) {


### PR DESCRIPTION
Set the flag 'FLAG_ACTIVITY_NEW_TASK' for the 'Intent' object before calling 'startActivity'. See https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/app/ContextImpl.java#955 for the reason why this might occasionally work when the flag is omitted.

Also remove the call to 'setAction', since explicit intents are being used.