### PR TITLE
Skip app extensions when searching frontmost app (on Fruity host session)

### DIFF
--- a/src/fruity/dtx.vala
+++ b/src/fruity/dtx.vala
@@ -62,6 +62,10 @@ namespace Frida.Fruity {
 				if (process.get_optional_value ("startDate", out start_date))
 					info.start_date = start_date.to_date_time ();
 
+				NSNumber? is_application;
+				if (process.get_optional_value ("isApplication", out is_application))
+					info.is_application = is_application.boolean;
+
 				result.add (info);
 			}
 
@@ -228,6 +232,11 @@ namespace Frida.Fruity {
 		}
 
 		public bool foreground_running {
+			get;
+			set;
+		}
+
+		public bool is_application {
 			get;
 			set;
 		}

--- a/src/fruity/dtx.vala
+++ b/src/fruity/dtx.vala
@@ -53,6 +53,7 @@ namespace Frida.Fruity {
 
 				info.name = process.get_value<NSString> ("name").str;
 				info.real_app_name = process.get_value<NSString> ("realAppName").str;
+				info.is_application = process.get_value<NSNumber> ("isApplication").boolean;
 
 				NSNumber? foreground_running;
 				if (process.get_optional_value ("foregroundRunning", out foreground_running))
@@ -61,10 +62,6 @@ namespace Frida.Fruity {
 				NSDate? start_date;
 				if (process.get_optional_value ("startDate", out start_date))
 					info.start_date = start_date.to_date_time ();
-
-				NSNumber? is_application;
-				if (process.get_optional_value ("isApplication", out is_application))
-					info.is_application = is_application.boolean;
 
 				result.add (info);
 			}
@@ -231,12 +228,12 @@ namespace Frida.Fruity {
 			set;
 		}
 
-		public bool foreground_running {
+		public bool is_application {
 			get;
 			set;
 		}
 
-		public bool is_application {
+		public bool foreground_running {
 			get;
 			set;
 		}

--- a/src/fruity/fruity-host-session.vala
+++ b/src/fruity/fruity-host-session.vala
@@ -447,7 +447,6 @@ namespace Frida {
 			DEBUGSERVER_ENDPOINT_MODERN,
 			DEBUGSERVER_ENDPOINT_LEGACY,
 		};
-		private const string SPRINGBOARD_PATH = "/System/Library/CoreServices/SpringBoard.app/SpringBoard";
 
 		public FruityHostSession (ChannelProvider channel_provider, FruityLockdownProvider lockdown_provider) {
 			Object (
@@ -498,7 +497,7 @@ namespace Frida {
 			var processes = yield device_info.enumerate_processes (cancellable);
 
 			var process = processes.first_match (p => p.foreground_running && p.is_application &&
-					!p.real_app_name.contains (".appex") && p.real_app_name != SPRINGBOARD_PATH);
+					!p.real_app_name.contains (".appex"));
 			if (process == null)
 				return HostApplicationInfo.empty ();
 

--- a/src/fruity/fruity-host-session.vala
+++ b/src/fruity/fruity-host-session.vala
@@ -497,7 +497,8 @@ namespace Frida {
 			var device_info = yield Fruity.DeviceInfoService.open (channel_provider, cancellable);
 			var processes = yield device_info.enumerate_processes (cancellable);
 
-			var process = processes.first_match (p => p.foreground_running && p.real_app_name != SPRINGBOARD_PATH);
+			var process = processes.first_match (p => p.foreground_running && p.is_application &&
+					!p.real_app_name.contains (".appex") && p.real_app_name != SPRINGBOARD_PATH);
 			if (process == null)
 				return HostApplicationInfo.empty ();
 


### PR DESCRIPTION
Sometimes an app extension was returned as the first matched process, just for failing right after with the “Unable to resolve bundle path to bundle ID” exception.