### PR TITLE
docs: fix simple typo, enviroment -> environment

### DIFF
--- a/lib/xnu/README.md
+++ b/lib/xnu/README.md
@@ -10,7 +10,7 @@ Experimental kernel driver for boosting Frida's capabilities on macOS:
 
 Run `reload.sh` to install and load the driver.
 
-If it fails to load, set `CODE_SIGN_IDENTITY` enviroment variable to
+If it fails to load, set `CODE_SIGN_IDENTITY` environment variable to
 identity valid for Kext signing, or disable SIP.
 
 To verify the installation, run this in a terminal:


### PR DESCRIPTION
There is a small typo in lib/xnu/README.md.

Should read `environment` rather than `enviroment`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md