### PR TITLE
Improve frida-inject to support rawio

### DIFF
--- a/inject/inject.vala
+++ b/inject/inject.vala
@@ -281,7 +281,7 @@ namespace Frida.Inject {
 
 #if WINDOWS
 		private bool read_raw (IOChannel source, IOCondition condition) {
-			assert_not_reached ();
+			return false;
 		}
 #else
 		private bool read_raw (IOChannel source, IOCondition condition) {


### PR DESCRIPTION
```bash
frida-inject --development -s test.js -p $PID -P '{"raw_mode": false}'
frida-inject --development -s test.js -p $PID -P '{"raw_mode": true}'
```

```javascript
function make_blue (message) {
    var escape = String.fromCharCode(parseInt('033', 8));
    var prefix = "[0;34m";
    var suffix = "[0m\n";
    var blue = `${escape}${prefix}${message.trim()}${escape}${suffix}`
    return blue;
}

rpc.exports = {
    raw_mode: false,
    init (stage, params) {
        var stageStr = make_blue (`STAGE > ${stage.trim()}`)
        send(['frida:stdout', stageStr]);
        var paramsData = make_blue (`PARAMS > ${params.raw_mode}`)
        send(['frida:stdout', paramsData]);
        this.raw_mode = params.raw_mode;
    },
    onFridaStdin (message) {
        var stdOutData = make_blue (`> ${message.trim()}`)
        send(['frida:stdout', `${stdOutData}\r`]);
    },
    onFridaGetStdInRawMode: function () {
        send(['frida:stdout', make_blue('onFridaGetStdInRawMode\n')]);
        return this.raw_mode;
    }
}

send(['frida:stdout', make_blue("STARTED\n")]);

var info = {
    type: "log",
    level: "info",
    payload: "> error message"
}
_send (JSON.stringify(info), null);

var warning = {
    type: "log",
    level: "warning",
    payload: "> warning message"
}
_send (JSON.stringify(warning), null);

var error = {
    type: "log",
    level: "error",
    payload: "> error message"
}
_send (JSON.stringify(error), null);

send ("BLAH");
send (["test1", "test2", "test3"]);
send ([123, "test"]);
send (["frida:stdout", 123]);
send ([{ key: 123, value: "test"}, "abc"]);
send (["frida:stdout", { key: 123, value: "test"}]);
send ({ key: 123, value: "test"});
send (null);
```