### PR TITLE
Fix agent call fail when FRIDA_V8=disabled

### DIFF
--- a/src/linux/linux-host-session.vala
+++ b/src/linux/linux-host-session.vala
@@ -823,7 +823,7 @@ namespace Frida {
 			Object (
 				host_session: host_session,
 				script_source: source,
-				script_runtime: ScriptRuntime.V8
+				script_runtime: ScriptRuntime.DEFAULT
 			);
 		}
 


### PR DESCRIPTION
when build android server with FRIDA_V8=disabled, frida-python will not work
self._impl.enumerate_processes(*args, **kwargs): frida.NotSupportedError: v8 runtime not available due to build configuration.
this is not a graceful fix.