### PR TITLE
Update pipe-darwin.c to use correct error string

### DIFF
--- a/lib/pipe/pipe-darwin.c
+++ b/lib/pipe/pipe-darwin.c
@@ -31,6 +31,7 @@ typedef char frida_pipe_uuid_t[36 + 1];
 #include "piped-client.c"
 
 extern kern_return_t bootstrap_look_up (mach_port_t bootstrap_port, const char * service_name, mach_port_t * service_port);
+extern const char *bootstrap_strerror (kern_return_t r);
 extern int fileport_makeport (int fd, mach_port_t * port);
 extern int fileport_makefd (mach_port_t port);
 extern int64_t sandbox_extension_consume (const char * extension_token);
@@ -239,7 +240,7 @@ mach_failure:
         FRIDA_ERROR,
         FRIDA_ERROR_NOT_SUPPORTED,
         "Unable to fetch file descriptor from %s (%s returned '%s')",
-        service, failed_operation, mach_error_string (kr));
+        service, failed_operation, bootstrap_strerror (kr));
     goto beach;
   }
 bsd_failure:

--- a/lib/pipe/pipe-darwin.c
+++ b/lib/pipe/pipe-darwin.c
@@ -37,7 +37,7 @@ typedef char frida_pipe_uuid_t[36 + 1];
 #include "piped-client.c"
 
 extern kern_return_t bootstrap_look_up (mach_port_t bootstrap_port, const char * service_name, mach_port_t * service_port);
-extern const char *bootstrap_strerror (kern_return_t r);
+extern const char * bootstrap_strerror (kern_return_t kr);
 extern int fileport_makeport (int fd, mach_port_t * port);
 extern int fileport_makefd (mach_port_t port);
 extern int64_t sandbox_extension_consume (const char * extension_token);


### PR DESCRIPTION
Update pipe-darwin.c to use bootstrap_strerror instead of mach_error_string for errors coming from bootstrap_look_up.  Currently the error printed every time is "Unknown error code"