### PR TITLE
Add 'no-bootstrap-service' option to frida-server

### DIFF
--- a/lib/pipe/pipe-darwin.c
+++ b/lib/pipe/pipe-darwin.c
@@ -31,6 +31,7 @@ typedef char frida_pipe_uuid_t[36 + 1];
 #include "piped-client.c"
 
 extern kern_return_t bootstrap_look_up (mach_port_t bootstrap_port, const char * service_name, mach_port_t * service_port);
+extern const char *bootstrap_strerror (kern_return_t r);
 extern int fileport_makeport (int fd, mach_port_t * port);
 extern int fileport_makefd (mach_port_t port);
 extern int64_t sandbox_extension_consume (const char * extension_token);
@@ -239,7 +240,7 @@ mach_failure:
         FRIDA_ERROR,
         FRIDA_ERROR_NOT_SUPPORTED,
         "Unable to fetch file descriptor from %s (%s returned '%s')",
-        service, failed_operation, mach_error_string (kr));
+        service, failed_operation, bootstrap_strerror (kr));
     goto beach;
   }
 bsd_failure:

--- a/lib/pipe/pipe-darwin.c
+++ b/lib/pipe/pipe-darwin.c
@@ -37,7 +37,7 @@ typedef char frida_pipe_uuid_t[36 + 1];
 #include "piped-client.c"
 
 extern kern_return_t bootstrap_look_up (mach_port_t bootstrap_port, const char * service_name, mach_port_t * service_port);
-extern const char *bootstrap_strerror (kern_return_t r);
+extern const char * bootstrap_strerror (kern_return_t kr);
 extern int fileport_makeport (int fd, mach_port_t * port);
 extern int fileport_makefd (mach_port_t port);
 extern int64_t sandbox_extension_consume (const char * extension_token);

--- a/server/server.vala
+++ b/server/server.vala
@@ -9,6 +9,9 @@ namespace Frida.Server {
 	private static string? token = null;
 	private static string? asset_root = null;
 	private static string? directory = null;
+#if DARWIN
+	private static bool use_bootstrap_service = true; 
+#endif
 #if !WINDOWS
 	private static bool daemonize = false;
 #endif
@@ -38,6 +41,9 @@ namespace Frida.Server {
 		{ "asset-root", 0, 0, OptionArg.FILENAME, ref asset_root, "Serve static files inside ROOT (by default no files are served)",
 			"ROOT" },
 		{ "directory", 'd', 0, OptionArg.STRING, ref directory, "Store binaries in DIRECTORY", "DIRECTORY" },
+#if DARWIN
+		{ "no-bootstrap-service", 0, OptionFlags.REVERSE, OptionArg.NONE, ref use_bootstrap_service, "Do not create a bootstrap service for IPC", null },
+#endif
 #if !WINDOWS
 		{ "daemonize", 'D', 0, OptionArg.NONE, ref daemonize, "Detach and become a daemon", null },
 #endif
@@ -89,6 +95,9 @@ namespace Frida.Server {
 		var options = new ControlServiceOptions ();
 		options.enable_preload = enable_preload;
 		options.report_crashes = report_crashes;
+#if DARWIN
+		options.use_bootstrap_service = use_bootstrap_service;
+#endif
 
 		PolicySoftenerFlavor softener_flavor = SYSTEM;
 		if (softener_flavor_str != null) {

--- a/src/control-service.vala
+++ b/src/control-service.vala
@@ -49,7 +49,7 @@ namespace Frida {
 			host_session = new WindowsHostSession (new WindowsHelperProcess (tempdir), tempdir);
 #endif
 #if DARWIN
-			host_session = new DarwinHostSession (new DarwinHelperBackend (), new TemporaryDirectory (),
+			host_session = new DarwinHostSession (new DarwinHelperBackend (opts.use_bootstrap_service), new TemporaryDirectory (),
 				opts.report_crashes);
 #endif
 #if LINUX
@@ -818,5 +818,14 @@ namespace Frida {
 			set;
 			default = true;
 		}
+
+#if DARWIN
+		public bool use_bootstrap_service {
+			get;
+			set;
+			default = true;
+		}
+#endif
+
 	}
 }

--- a/src/darwin/frida-helper-backend.vala
+++ b/src/darwin/frida-helper-backend.vala
@@ -17,6 +17,11 @@ namespace Frida {
 			}
 		}
 
+		public bool use_bootstrap_service {
+			get;
+			construct;
+		}
+
 		protected delegate void DispatchWorker ();
 		protected delegate void LaunchCompletionHandler (owned StdioPipes? pipes, owned Error? error);
 
@@ -39,8 +44,12 @@ namespace Frida {
 
 		private Cancellable io_cancellable = new Cancellable ();
 
+		public DarwinHelperBackend (bool use_bootstrap_service = true) {
+			Object (use_bootstrap_service: use_bootstrap_service);
+		}
+
 		construct {
-			_create_context ();
+			_create_context (use_bootstrap_service);
 
 			dtrace_agent = DTraceAgent.try_open ();
 			if (dtrace_agent != null) {
@@ -624,7 +633,7 @@ namespace Frida {
 		public extern static bool is_mmap_available ();
 		public extern static MappedLibraryBlob mmap (uint task, Bytes blob) throws Error;
 
-		protected extern void _create_context ();
+		protected extern void _create_context (bool use_bootstrap_service);
 		protected extern void _destroy_context ();
 		protected extern void _schedule_on_dispatch_queue (DispatchWorker worker);
 


### PR DESCRIPTION
Add option to not register a bootstrap service and just rely on the stashed mach port. For some unknown reason to me, [the sandbox extension code](https://github.com/frida/frida-core/blob/master/src/darwin/frida-helper-backend-glue.m) in the `frida_darwin_helper_backend_make_pipe_endpoints` function fails transparently for some processes (apsd, imagent, etc) on Big Sur. With no fallback options, it makes it impossible to hook these applications. This option allows a user to specify to not use the bootstrap server and instead fall back on just the traditional mach port IPC.

This also seems to be causing other people issues:
https://github.com/frida/frida/issues/1829
https://github.com/frida/frida/issues/1830
https://github.com/frida/frida/issues/1719

Here's an example with apsd without `--no-bootstrap-service`
![Screen Shot 2021-09-02 at 5 14 42 PM](https://user-images.githubusercontent.com/5934002/131917094-3e30a011-de1f-4a9c-8c69-04316cd09130.png)

Here's an example with apsd with `--no-bootstrap-service`
![Screen Shot 2021-09-02 at 5 18 02 PM](https://user-images.githubusercontent.com/5934002/131917505-968b90e5-c62e-42bc-b543-d444329fcea8.png)

