### PR TITLE
Add NO_BOOTSTRAP_SERVICE environment variable functionality

### DIFF
--- a/lib/pipe/pipe-darwin.c
+++ b/lib/pipe/pipe-darwin.c
@@ -31,6 +31,7 @@ typedef char frida_pipe_uuid_t[36 + 1];
 #include "piped-client.c"
 
 extern kern_return_t bootstrap_look_up (mach_port_t bootstrap_port, const char * service_name, mach_port_t * service_port);
+extern const char *bootstrap_strerror (kern_return_t r);
 extern int fileport_makeport (int fd, mach_port_t * port);
 extern int fileport_makefd (mach_port_t port);
 extern int64_t sandbox_extension_consume (const char * extension_token);
@@ -239,7 +240,7 @@ mach_failure:
         FRIDA_ERROR,
         FRIDA_ERROR_NOT_SUPPORTED,
         "Unable to fetch file descriptor from %s (%s returned '%s')",
-        service, failed_operation, mach_error_string (kr));
+        service, failed_operation, bootstrap_strerror (kr));
     goto beach;
   }
 bsd_failure:

--- a/lib/pipe/pipe-darwin.c
+++ b/lib/pipe/pipe-darwin.c
@@ -37,7 +37,7 @@ typedef char frida_pipe_uuid_t[36 + 1];
 #include "piped-client.c"
 
 extern kern_return_t bootstrap_look_up (mach_port_t bootstrap_port, const char * service_name, mach_port_t * service_port);
-extern const char *bootstrap_strerror (kern_return_t r);
+extern const char * bootstrap_strerror (kern_return_t kr);
 extern int fileport_makeport (int fd, mach_port_t * port);
 extern int fileport_makefd (mach_port_t port);
 extern int64_t sandbox_extension_consume (const char * extension_token);

--- a/src/darwin/frida-helper-backend-glue.m
+++ b/src/darwin/frida-helper-backend-glue.m
@@ -797,36 +797,42 @@ _frida_darwin_helper_backend_create_context (FridaDarwinHelperBackend * self)
 {
   FridaHelperContext * ctx;
   kern_return_t kr;
+  const gchar * no_bootstrap_service = g_getenv("NO_BOOTSTRAP_SERVICE");
 
   ctx = g_slice_new (FridaHelperContext);
   ctx->dispatch_queue = dispatch_queue_create ("re.frida.helper.queue", DISPATCH_QUEUE_SERIAL);
-
-  ctx->piped_name = g_strdup_printf ("re.frida.piped.%u", getpid ());
-  mach_port_allocate (mach_task_self (), MACH_PORT_RIGHT_RECEIVE, &ctx->piped_port);
   ctx->stashed_pipes = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, (GDestroyNotify) frida_stashed_pipe_free);
-
+  ctx->piped_port = MACH_PORT_NULL;
+  ctx->piped_name = NULL;
   g_mutex_init (&ctx->mutex);
 
   self->context = ctx;
 
-  kr = bootstrap_register (bootstrap_port, ctx->piped_name, ctx->piped_port);
-  if (kr == KERN_SUCCESS)
+  if (no_bootstrap_service == NULL ||
+      !(g_strcmp0(no_bootstrap_service, "true") == 0 || g_strcmp0(no_bootstrap_service, "TRUE") == 0))
   {
-    dispatch_source_t source;
+    ctx->piped_name = g_strdup_printf ("re.frida.piped.%u", getpid ());
+    mach_port_allocate (mach_task_self (), MACH_PORT_RIGHT_RECEIVE, &ctx->piped_port);
 
-    source = dispatch_source_create (DISPATCH_SOURCE_TYPE_MACH_RECV, ctx->piped_port, 0, ctx->dispatch_queue);
-    ctx->piped_source = source;
-    dispatch_set_context (source, self);
-    dispatch_source_set_event_handler_f (source, frida_darwin_helper_backend_on_piped_recv);
-    dispatch_resume (source);
-  }
-  else
-  {
-    mach_port_deallocate (mach_task_self (), ctx->piped_port);
-    ctx->piped_port = MACH_PORT_NULL;
+    kr = bootstrap_register (bootstrap_port, ctx->piped_name, ctx->piped_port);
+    if (kr == KERN_SUCCESS)
+    {
+      dispatch_source_t source;
 
-    g_free (ctx->piped_name);
-    ctx->piped_name = NULL;
+      source = dispatch_source_create (DISPATCH_SOURCE_TYPE_MACH_RECV, ctx->piped_port, 0, ctx->dispatch_queue);
+      ctx->piped_source = source;
+      dispatch_set_context (source, self);
+      dispatch_source_set_event_handler_f (source, frida_darwin_helper_backend_on_piped_recv);
+      dispatch_resume (source);
+    }
+    else
+    {
+      mach_port_deallocate (mach_task_self (), ctx->piped_port);
+      ctx->piped_port = MACH_PORT_NULL;
+
+      g_free (ctx->piped_name);
+      ctx->piped_name = NULL;
+    }
   }
 }
 

--- a/src/darwin/frida-helper-backend-glue.m
+++ b/src/darwin/frida-helper-backend-glue.m
@@ -797,7 +797,7 @@ _frida_darwin_helper_backend_create_context (FridaDarwinHelperBackend * self)
 {
   FridaHelperContext * ctx;
   kern_return_t kr;
-  const gchar * no_bootstrap_service = g_getenv("NO_BOOTSTRAP_SERVICE");
+  const gchar * no_bootstrap_service = g_getenv ("NO_BOOTSTRAP_SERVICE");
 
   ctx = g_slice_new (FridaHelperContext);
   ctx->dispatch_queue = dispatch_queue_create ("re.frida.helper.queue", DISPATCH_QUEUE_SERIAL);
@@ -809,7 +809,7 @@ _frida_darwin_helper_backend_create_context (FridaDarwinHelperBackend * self)
   self->context = ctx;
 
   if (no_bootstrap_service == NULL ||
-      !(g_strcmp0(no_bootstrap_service, "true") == 0 || g_strcmp0(no_bootstrap_service, "TRUE") == 0))
+      !(g_strcmp0 (no_bootstrap_service, "true") == 0 || g_strcmp0 (no_bootstrap_service, "TRUE") == 0))
   {
     ctx->piped_name = g_strdup_printf ("re.frida.piped.%u", getpid ());
     mach_port_allocate (mach_task_self (), MACH_PORT_RIGHT_RECEIVE, &ctx->piped_port);


### PR DESCRIPTION
Based on feedback from https://github.com/frida/frida-core/pull/391, changed the functionality to just look for a NO_BOOTSTRAP_SERVICE environment variable as a temporary solution to this issue.