### PR TITLE
portal-service: Always remove ClusterNode and ControlChannel sessions

### DIFF
--- a/src/portal-service.vala
+++ b/src/portal-service.vala
@@ -489,12 +489,13 @@ namespace Frida {
 				AgentSession? session = entry.session;
 				if (entry.persist_timeout == 0 || session == null) {
 					sessions.unset (id);
-					if (session != null)
-						session.close.begin (io_cancellable);
 
 					ClusterNode? node = entry.node;
 					if (node != null)
 						node.sessions.remove (id);
+
+					if (session != null)
+						session.close.begin (io_cancellable);
 				} else {
 					entry.detach_controller ();
 					session.interrupt.begin (io_cancellable);
@@ -845,10 +846,6 @@ namespace Frida {
 			ClusterNode? node = entry.node;
 			if (node != null)
 				node.sessions.remove (entry.id);
-
-			ControlChannel? controller = entry.controller;
-			if (controller != null)
-				controller.sessions.remove (entry.id);
 		}
 
 		private void on_agent_session_closed (AgentSessionId id) {

--- a/src/portal-service.vala
+++ b/src/portal-service.vala
@@ -491,6 +491,10 @@ namespace Frida {
 					sessions.unset (id);
 					if (session != null)
 						session.close.begin (io_cancellable);
+
+					ClusterNode? node = entry.node;
+					if (node != null)
+						node.sessions.remove (id);
 				} else {
 					entry.detach_controller ();
 					session.interrupt.begin (io_cancellable);
@@ -837,6 +841,14 @@ namespace Frida {
 
 		private void on_agent_session_expired (AgentSessionEntry entry) {
 			sessions.unset (entry.id);
+
+			ClusterNode? node = entry.node;
+			if (node != null)
+				node.sessions.remove (entry.id);
+
+			ControlChannel? controller = entry.controller;
+			if (controller != null)
+				controller.sessions.remove (entry.id);
 		}
 
 		private void on_agent_session_closed (AgentSessionId id) {


### PR DESCRIPTION
Whenever a session id is unset from PortalService. This avoids both NULL derefereces and leaks.