### PR TITLE
Fix "cannot read property 'slot' of undefined" error

### DIFF
--- a/src/darwin/agent/launchd.js
+++ b/src/darwin/agent/launchd.js
@@ -240,9 +240,8 @@ function findSubstrateLauncher() {
     return null;
 
   const imp = Module.enumerateImports('/sbin/launchd').filter(imp => imp.name === 'posix_spawn')[0];
-  if (!imp || !imp.slot) {
+  if (imp === undefined)
     return null;
-  }
   const impl = imp.slot.readPointer().strip();
   const header = findClosestMachHeader(impl);
 

--- a/src/darwin/agent/launchd.js
+++ b/src/darwin/agent/launchd.js
@@ -240,6 +240,9 @@ function findSubstrateLauncher() {
     return null;
 
   const imp = Module.enumerateImports('/sbin/launchd').filter(imp => imp.name === 'posix_spawn')[0];
+  if (!imp || !imp.slot) {
+    return null;
+  }
   const impl = imp.slot.readPointer().strip();
   const header = findClosestMachHeader(impl);
 


### PR DESCRIPTION
Device: iPhone 11 Pro
System: iOS 14.2
Jailbreak: Taurine 1.1.3

When using `frida -U -f xxx.xxx.xxx`, the following error occurs:

```shell
iPhone-11-Pro:~ root# /usr/sbin/frida-server -v
{"type":"error","description":"TypeError: cannot read property 'slot' of undefined","stack":"TypeError: cannot read property 'slot' of undefined\n    at findSubstrateLauncher (/internal-agent.js:243)\n    at applyJailbreakQuirks (/internal-agent.js:152)\n    at <eval> (/internal-agent.js:50)","fileName":"/internal-agent.js","lineNumber":243,"columnNumber":1}
```

It's strange that executing `Module.enumerateImports('/sbin/launchd').filter(imp => imp.name === 'posix_spawn')[0]` on this device doesn't get the corresponding implementation.

This PR simply makes a judgment and bypasses the problem.