### PR TITLE
Fix use after free in crash delivery

### DIFF
--- a/src/linux/linux-host-session.vala
+++ b/src/linux/linux-host-session.vala
@@ -1345,8 +1345,10 @@ namespace Frida {
 			}
 
 			public void disable_timeout () {
-				expiry_source.destroy ();
-				expiry_source = null;
+				if (expiry_source != null) {
+					expiry_source.destroy ();
+					expiry_source = null;
+				}
 			}
 
 			private TimeoutSource make_expiry_source (uint timeout) {


### PR DESCRIPTION
In case a crash is reported after a Java crash has already been delivered.
E.g. in apps that set their own uncaught exception handler, rendering
uncaught exceptions non-fatal.