### PR TITLE
frida-server: Fix daemon parent ready() fail exit

### DIFF
--- a/portal/portal.vala
+++ b/portal/portal.vala
@@ -133,8 +133,8 @@ namespace Frida.Portal {
 		});
 
 		if (on_ready != null) {
-			application.ready.connect (() => {
-				on_ready (true);
+			application.ready.connect (success => {
+				on_ready (success);
 				on_ready = null;
 			});
 		}
@@ -143,7 +143,7 @@ namespace Frida.Portal {
 	}
 
 	private class Application : Object {
-		public signal void ready ();
+		public signal void ready (bool success);
 
 		public PortalService service {
 			get;
@@ -182,11 +182,12 @@ namespace Frida.Portal {
 				printerr ("Unable to start: %s\n", e.message);
 				exit_code = 4;
 				loop.quit ();
+				ready (false);
 				return;
 			}
 
 			Idle.add (() => {
-				ready ();
+				ready (true);
 				return false;
 			});
 		}

--- a/server/server.vala
+++ b/server/server.vala
@@ -190,8 +190,8 @@ namespace Frida.Server {
 		});
 
 		if (on_ready != null) {
-			application.ready.connect (() => {
-				on_ready (true);
+			application.ready.connect (success => {
+				on_ready (success);
 				on_ready = null;
 			});
 		}
@@ -215,7 +215,7 @@ namespace Frida.Server {
 #endif
 
 	private class Application : Object {
-		public signal void ready ();
+		public signal void ready (bool success);
 
 		public ControlService service {
 			get;
@@ -254,11 +254,12 @@ namespace Frida.Server {
 				printerr ("Unable to start: %s\n", e.message);
 				exit_code = 5;
 				loop.quit ();
+				ready (false);
 				return;
 			}
 
 			Idle.add (() => {
-				ready ();
+				ready (true);
 				return false;
 			});
 		}


### PR DESCRIPTION
The frida-server Application class can now signal success or failure on `ready()` to allow for the daemon's parent to exit on failures.
See:  https://github.com/frida/frida-core/issues/429

Example
```
sunfish:/ # /data/local/tmp/frida-server -D
# This failure now triggers an exit
sunfish:/ # /data/local/tmp/frida-server -D                                                                                                                                        
Unable to start: Could not listen on address 127.0.0.1, port 27042: Error binding to address 127.0.0.1:27042: Address already in use
1|sunfish:/ # 
```