### PR TITLE
Remove usbmuxd confusing envvars

### DIFF
--- a/src/droidy/droidy-client.vala
+++ b/src/droidy/droidy-client.vala
@@ -800,7 +800,7 @@ namespace Frida.Droidy {
 			string? server_socket = Environment.get_variable ("ADB_SERVER_SOCKET");
 			if (server_socket != null) {
 				MatchInfo info;
-				if (/^tcp:([\d\w.:]+):([\d]+)$/.match (server_socket, 0, out info)) {
+				if (/^tcp:([\d\w.:-]+):([\d]+)$/.match (server_socket, 0, out info)) {
 					server_host = info.fetch (1);
 					server_port = (uint16) uint.parse (info.fetch (2));
 				} else if (/^tcp:([\d]+)$/.match (server_socket, 0, out info)) {

--- a/src/droidy/droidy-client.vala
+++ b/src/droidy/droidy-client.vala
@@ -794,34 +794,36 @@ namespace Frida.Droidy {
 		private const uint16 MAX_MESSAGE_LENGTH = 1024;
 
 		public static async Client open (Cancellable? cancellable = null) throws Error, IOError {
-			string? server_host = null;
-			uint16 server_port = ADB_SERVER_DEFAULT_PORT;
-
-			string? server_socket = Environment.get_variable ("ADB_SERVER_SOCKET");
-			if (server_socket != null) {
-				MatchInfo info;
-				if (/^tcp:([\d\w.:-]+):([\d]+)$/.match (server_socket, 0, out info)) {
-					server_host = info.fetch (1);
-					server_port = (uint16) uint.parse (info.fetch (2));
-				} else if (/^tcp:([\d]+)$/.match (server_socket, 0, out info)) {
-					server_port = (uint16) uint.parse (info.fetch (1));
-				} else {
-					throw new Error.INVALID_ARGUMENT ("Bad ADB_SERVER_SOCKET environment variable (%s)", server_socket);
+			SocketConnectable connectable;
+			string? env_socket_address = Environment.get_variable ("ADB_SERVER_SOCKET");
+			string? env_server_address = Environment.get_variable ("ANDROID_ADB_SERVER_ADDRESS");
+			string? env_server_port = Environment.get_variable ("ANDROID_ADB_SERVER_PORT");
+			if (env_socket_address != null) {
+				try {
+					connectable = NetworkAddress.parse_uri (env_socket_address, ADB_SERVER_DEFAULT_PORT);
+				} catch (GLib.Error e) {
+					connectable = NetworkAddress.parse (env_socket_address, ADB_SERVER_DEFAULT_PORT);
 				}
+			} else if (env_server_address != null && env_server_port != null) {
+				connectable = new NetworkAddress (
+					env_server_address,
+					(uint16) uint.parse (env_server_port)
+				);
+			} else if (env_server_address != null) {
+				connectable = new NetworkAddress (
+					env_server_address,
+					ADB_SERVER_DEFAULT_PORT
+				);
+			} else if (env_server_port != null) {
+				connectable = new NetworkAddress.loopback ((uint16) uint.parse (env_server_port));
 			} else {
-				server_host = Environment.get_variable ("ANDROID_ADB_SERVER_ADDRESS");
-				string? server_port_str = Environment.get_variable ("ANDROID_ADB_SERVER_PORT");
-				if (server_port_str != null)
-					server_port = (uint16) uint.parse (server_port_str);
+				connectable = new NetworkAddress.loopback (ADB_SERVER_DEFAULT_PORT);
 			}
 
 			IOStream stream;
 			try {
 				var client = new SocketClient ();
-				NetworkAddress address = (server_host != null)
-					? new NetworkAddress (server_host, server_port)
-					: new NetworkAddress.loopback (server_port);
-				var connection = yield client.connect_async (address, cancellable);
+				var connection = yield client.connect_async (connectable, cancellable);
 
 				Tcp.enable_nodelay (connection.socket);
 

--- a/src/fruity/usbmux.vala
+++ b/src/fruity/usbmux.vala
@@ -43,26 +43,12 @@ namespace Frida.Fruity {
 			SocketConnectable connectable;
 
 			string? env_socket_address = Environment.get_variable ("USBMUXD_SOCKET_ADDRESS");
-			string? env_server_address = Environment.get_variable ("USBMUXD_SERVER_ADDRESS");
-			string? env_server_port = Environment.get_variable ("USBMUXD_SERVER_PORT");
 			if (env_socket_address != null) {
 				try {
 					connectable = NetworkAddress.parse_uri (env_socket_address, USBMUXD_DEFAULT_SERVER_PORT);
 				} catch (GLib.Error e) {
 					connectable = NetworkAddress.parse (env_socket_address, USBMUXD_DEFAULT_SERVER_PORT);
 				}
-			} else if (env_server_address != null && env_server_port != null) {
-				connectable = new NetworkAddress (
-					env_server_address,
-					(uint16) uint.parse (env_server_port)
-				);
-			} else if (env_server_address != null) {
-				connectable = new NetworkAddress (
-					env_server_address,
-					USBMUXD_DEFAULT_SERVER_PORT
-				);
-			} else if (env_server_port != null) {
-				connectable = new NetworkAddress.loopback ((uint16) uint.parse (env_server_port));
 			} else if (File.new_for_path ("/var/run/usbmuxd").query_exists () == true) {
 				connectable = new UnixSocketAddress ("/var/run/usbmuxd");
 			} else {

--- a/src/fruity/usbmux.vala
+++ b/src/fruity/usbmux.vala
@@ -53,7 +53,7 @@ namespace Frida.Fruity {
 			string? server_socket = Environment.get_variable ("USBMUXD_SOCKET_ADDRESS");
 			if (server_socket != null) {
 				MatchInfo info;
-				if (/^([\d\w.:]+):([\d]+)$/.match (server_socket, 0, out info)) {
+				if (/^([\d\w.:-]+):([\d]+)$/.match (server_socket, 0, out info)) {
 					server_host = info.fetch (1);
 					server_port = (uint16) uint.parse (info.fetch (2));
 				} else {


### PR DESCRIPTION
This MR is based on https://github.com/frida/frida-core/pull/426.

It removes USBMUXD_SERVER_ADDRESS and USBMUXD_SERVER_PORT environment variables because can be confusing with USBMUXD_SOCKET_ADDRESS which is the one used by `libusbmuxd` too.