### PR TITLE
Add missing openssl dependency

### DIFF
--- a/lib/base/meson.build
+++ b/lib/base/meson.build
@@ -19,7 +19,7 @@ base = static_library('frida-base-' + api_version, base_sources,
   c_args: frida_component_cflags,
   vala_header: 'frida-base.h',
   vala_vapi: f'frida-base-@api_version@.vapi',
-  dependencies: [glib_dep, gobject_dep, gio_dep, libsoup_dep, nice_dep, usrsctp_dep, gee_dep, json_glib_dep, gum_dep] + extra_deps,
+  dependencies: [glib_dep, gobject_dep, gio_dep, libsoup_dep, nice_dep, usrsctp_dep, gee_dep, json_glib_dep, gum_dep, openssl_dep] + extra_deps,
   install: true,
   install_dir: [true, header_install_dir, true],
 )


### PR DESCRIPTION
I'm not sure how it worked for others. Maybe when `gioopenssl` is present it also solve the required openssl headers?