### PR TITLE
Rethrow the original error when resume fails inside the error handler

### DIFF
--- a/src/linux/frida-helper-process.vala
+++ b/src/linux/frida-helper-process.vala
@@ -85,11 +85,16 @@ namespace Frida {
 			} catch (Error e) {
 				if (!(e is Error.INVALID_ARGUMENT))
 					throw e;
-				if (cpu_type == Gum.CpuType.AMD64 || cpu_type == Gum.CpuType.ARM64)
-					helper = yield obtain_for_32bit (cancellable);
-				else
-					helper = yield obtain_for_64bit (cancellable);
-				yield helper.resume (pid, cancellable);
+				try {
+					if (cpu_type == Gum.CpuType.AMD64 || cpu_type == Gum.CpuType.ARM64)
+						helper = yield obtain_for_32bit (cancellable);
+					else
+						helper = yield obtain_for_64bit (cancellable);
+					yield helper.resume (pid, cancellable);
+				} catch (Error _e) {
+					// Intentionally rethrowing the original error instead of the new error
+					throw e;
+				}
 			}
 		}
 


### PR DESCRIPTION
I'm not too familiar with Vala, but this seems to work

Fixes #447 