### PR TITLE
merge.sh: Fix ar script: Use addmod for object files

### DIFF
--- a/src/api/merge.sh
+++ b/src/api/merge.sh
@@ -16,7 +16,13 @@ else
 
   echo "create $output_lib" > "$mri_script"
   while [[ $# > 0 ]]; do
-    echo "addlib $1" >> "$mri_script"
+    ext=${1##*.}
+    if [[ "$ext" == 'a' ]]; then
+      echo "addlib $1" >> "$mri_script"
+    else
+      # $1 is *.o or *.so
+      echo "addmod $1" >> "$mri_script"
+    fi
     shift
   done
   echo "save" >> "$mri_script"


### PR DESCRIPTION
fix build on linux, where `libtool` is empty

fix #453

> merge.sh: Fix ar script: Use addmod for object files

maybe rename to `merge.sh: Fix build on Linux`
