### PR TITLE
Support loading frida-server as shared library

### DIFF
--- a/server/frida-server.version
+++ b/server/frida-server.version
@@ -6,7 +6,6 @@
     # Allow users to load the server as a shared library with dlopen() and call main() directly
     main;
 
-
   local:
     *;
 };

--- a/server/frida-server.version
+++ b/server/frida-server.version
@@ -3,6 +3,9 @@
     # FreeBSD needs these two:
     __progname;
     environ;
+    # Allow users to load the server as shared library with `dlopen` and call `main` directly
+    main;
+
 
   local:
     *;

--- a/server/frida-server.version
+++ b/server/frida-server.version
@@ -3,7 +3,7 @@
     # FreeBSD needs these two:
     __progname;
     environ;
-    # Allow users to load the server as shared library with `dlopen` and call `main` directly
+    # Allow users to load the server as a shared library with dlopen() and call main() directly
     main;
 
 


### PR DESCRIPTION
This change ensures the `main` symbol in frida-server artifact is retained during build. On non-rooted Android in some contexts one can't execute binaries from various locations but can load them using `dlopen` and other tricks. If a user manages to trigger `dlopen` + `dlsym` they can invoke `main` directly from within the process they are running without further hacks.