### PR TITLE
darwin: Make ThreadSuspendMonitor passthrough if called by Frida

### DIFF
--- a/lib/payload/thread-suspend-monitor.vala
+++ b/lib/payload/thread-suspend-monitor.vala
@@ -119,9 +119,9 @@ namespace Frida {
 		}
 
 		private bool is_called_by_frida (Gum.InvocationContext context) {
-			var range = invader.get_memory_range ();
-			var caller = (Gum.Address) context.get_return_address ();
-			return (caller >= range.base_address && caller < range.base_address + range.size);
+			Gum.MemoryRange range = invader.get_memory_range ();
+			var caller = Gum.Address.from_pointer (context.get_return_address ());
+			return caller >= range.base_address && caller < range.base_address + range.size;
 		}
 	}
 #else

--- a/lib/payload/thread-suspend-monitor.vala
+++ b/lib/payload/thread-suspend-monitor.vala
@@ -49,6 +49,9 @@ namespace Frida {
 			unowned Gum.InvocationContext context = Gum.Interceptor.get_current_invocation ();
 			unowned ThreadSuspendMonitor monitor = (ThreadSuspendMonitor) context.get_replacement_data ();
 
+			if (monitor.is_called_by_frida (context))
+				return monitor.task_threads (task_id, threads, count);
+
 			return monitor.handle_task_threads (task_id, threads, count);
 		}
 
@@ -65,6 +68,9 @@ namespace Frida {
 		private static int replacement_thread_suspend (uint thread_id) {
 			unowned Gum.InvocationContext context = Gum.Interceptor.get_current_invocation ();
 			unowned ThreadSuspendMonitor monitor = (ThreadSuspendMonitor) context.get_replacement_data ();
+
+			if (monitor.is_called_by_frida (context))
+				return monitor.thread_suspend (thread_id);
 
 			return monitor.handle_thread_suspend (thread_id);
 		}
@@ -99,6 +105,9 @@ namespace Frida {
 			unowned Gum.InvocationContext context = Gum.Interceptor.get_current_invocation ();
 			unowned ThreadSuspendMonitor monitor = (ThreadSuspendMonitor) context.get_replacement_data ();
 
+			if (monitor.is_called_by_frida (context))
+				return monitor.thread_resume (thread_id);
+
 			return monitor.handle_thread_resume (thread_id);
 		}
 
@@ -107,6 +116,12 @@ namespace Frida {
 				return 0;
 
 			return thread_resume (thread_id);
+		}
+
+		private bool is_called_by_frida (Gum.InvocationContext context) {
+			var range = invader.get_memory_range ();
+			var caller = (Gum.Address) context.get_return_address ();
+			return (caller >= range.base_address && caller < range.base_address + range.size);
 		}
 	}
 #else


### PR DESCRIPTION
In this way we're sure this kind of crashes won't happen anymore:

```
Exception Type:  EXC_BAD_ACCESS (SIGBUS)
Exception Subtype: KERN_PROTECTION_FAILURE at 0x00000001bbfee294
Exception Codes: 0x0000000000000002, 0x00000001bbfee294
VM Region Info: 0x1bbfee294 is in 0x1bbfec000-0x1bbff4000;  bytes after start: 8852  bytes before end: 23915
      REGION TYPE                 START - END      [ VSIZE] PRT/MAX SHRMOD  REGION DETAIL
      unused shlib __TEXT      1bbb01000-1bbfec000 [ 5036K] r-x/r-x SM=COW  ... this process
--->  __TEXT                   1bbfec000-1bbff4000 [   32K] r-x/rwx SM=COW  ..._kernel.dylib
      __TEXT                   1bbff4000-1bbff8000 [   16K] r-x/r-x SM=COW  ..._kernel.dylib
Exception Note:  EXC_CORPSE_NOTIFY
Termination Reason: SIGNAL 10 Bus error: 10
Terminating Process: exc handler [1185]

Triggered by Thread:  5

Thread 5 name:  gdbus
Thread 5 Crashed:
0   libsystem_kernel.dylib        	       0x1bbfee294 kevent + 8
1   ???                           	       0x108d11588 ???
2   ???                           	       0x108d10a3c ???
3   ???                           	       0x108d10c10 ???
4   ???                           	       0x108ccc690 ???
5   ???                           	       0x108d1f100 ???
6   libsystem_pthread.dylib       	       0x1dca8a338 _pthread_start + 116
7   libsystem_pthread.dylib       	       0x1dca88938 thread_start + 8
```

Which happened because:
- a Frida thread tried to execute some function while the page in which the function lived was writable
- `ThreadSuspendMonitor` prevented `thread_suspend` (called by the Interceptor) from working on that thread

this happened quite frequently at teardown time, when all Interceptor hooks get removed.

**Note**: ~~WIP because i'm going to test this change thoroughly~~ test succeeded