### PR TITLE
agent: Dispose ThreadSuspendMonitor in its own transaction

### DIFF
--- a/lib/agent/agent.vala
+++ b/lib/agent/agent.vala
@@ -242,15 +242,19 @@ namespace Frida.Agent {
 
 			disable_child_gating ();
 
-			thread_suspend_monitor = null;
-
 			exceptor = null;
 
 			exit_monitor = null;
 
 			interceptor.end_transaction ();
 
+			interceptor.begin_transaction ();
+
+			thread_suspend_monitor = null;
+
 			invalidate_dbus_context ();
+
+			interceptor.end_transaction ();
 		}
 
 		private void run (owned FileDescriptorTablePadder padder) throws Error {


### PR DESCRIPTION
Since Interceptor relies on ThreadSuspendMonitor passthrough, disposing of it in its own transaction and after all the other components which use Interceptor at destruction time makes sure no frida thread will attempt executing code on non-executable pages at teardown time.

(This is the second part of https://github.com/frida/frida-core/pull/463)