### PR TITLE
darwin: Make spawn aware of prewarm

### DIFF
--- a/src/darwin/agent/launchd.js
+++ b/src/darwin/agent/launchd.js
@@ -52,9 +52,10 @@ applyJailbreakQuirks();
 Interceptor.attach(Module.getExportByName('/usr/lib/system/libsystem_kernel.dylib', '__posix_spawn'), {
   onEnter(args) {
     const envp = args[4];
-    if (isPrewarmLaunch(envp)) {
+    const prewarm = isPrewarmLaunch(envp);
+
+    if (prewarm && !gating)
       return;
-    }
 
     const path = args[1].readUtf8String();
 
@@ -70,7 +71,7 @@ Interceptor.attach(Module.getExportByName('/usr/lib/system/libsystem_kernel.dyli
     let identifier, event;
     if (rawIdentifier.startsWith('UIKitApplication:')) {
       identifier = rawIdentifier.substring(17, rawIdentifier.indexOf('['));
-      if (upcoming.has(identifier))
+      if (!prewarm && upcoming.has(identifier))
         event = 'launch:app';
       else if (gating)
         event = 'spawn';

--- a/src/darwin/agent/launchd.js
+++ b/src/darwin/agent/launchd.js
@@ -149,21 +149,14 @@ function parseStringv(p) {
 }
 
 function isPrewarmLaunch(env) {
-  for (const element of env) {
-    if (element.startsWith('ActivePrewarm='))
-      return true;
-  }
-
-  return false;
+  return env.some(candidate => candidate.startsWith('ActivePrewarm='));
 }
 
 function tryParseXpcServiceName(env) {
-  for (const element of env) {
-    if (element.startsWith('XPC_SERVICE_NAME='))
-      return element.substring(17);
-  }
-
-  return null;
+  const entry = env.find(candidate => candidate.startsWith('XPC_SERVICE_NAME='));
+  if (entry === undefined)
+    return null;
+  return entry.substring(17);
 }
 
 function applyJailbreakQuirks() {

--- a/src/darwin/frida-helper-backend-glue.m
+++ b/src/darwin/frida-helper-backend-glue.m
@@ -1489,8 +1489,6 @@ frida_has_active_prewarm (gint pid)
 
   if (sysctl (mib_args, G_N_ELEMENTS (mib_args), buffer, &size, NULL, 0) != 0)
     goto beach;
-  if (size < sizeof (argc))
-    goto beach;
 
   argc = *(gint32 *) buffer;
   end = buffer + size;

--- a/src/darwin/frida-helper-backend-glue.m
+++ b/src/darwin/frida-helper-backend-glue.m
@@ -1506,7 +1506,7 @@ frida_has_active_prewarm (gint pid)
   /* Iterate environment */
   while (cursor != end)
   {
-    if (strstr ((char *)cursor, "ActivePrewarm=1") != NULL)
+    if (strstr ((char *) cursor, "ActivePrewarm=1") != NULL)
     {
       prewarm_active = true;
       break;

--- a/src/darwin/frida-helper-backend-glue.m
+++ b/src/darwin/frida-helper-backend-glue.m
@@ -1492,7 +1492,7 @@ frida_has_active_prewarm (gint pid)
   if (size < sizeof (argc))
     goto beach;
 
-  argc = *(gint32 *)buffer;
+  argc = *(gint32 *) buffer;
   end = buffer + size;
   cursor = buffer + sizeof (argc);
 
@@ -1523,12 +1523,10 @@ beach:
 static guint8 *
 frida_skip_string (guint8 * cursor, guint8 * end)
 {
-  while (cursor != end && *cursor != 0)
-    cursor++;
-  while (cursor != end && *cursor == 0)
+  while (cursor != end && *cursor != '\0')
     cursor++;
 
-  return cursor;
+  return ++cursor;
 }
 
 static NSArray *


### PR DESCRIPTION
Since iOS 15, Darwin has the "prewarm" feature for which most frequently used apps are being spawned ahead of time by `dasd` and kept suspended until the user attempts to launch them, in order to save some startup time.

This was in the way of Frida's spawn mechanism because:

- apps launched that way won't be going through launchd when expected, causing a "timeout was reached" error, or more complex race conditions
- Frida needs to spawn a fresh process to ensure early instrumentation

This change addresses these problems by:

- ignoring prewarm spawns from the launchd agent  (but they're still emitted as spawns if spawn gating is enabled)
- killing existing prewarmed apps before attempting to spawn them

The detection of prewarmed apps is done by checking the presence of the `ActivePrewarm=1` environment variable (libSystem makes the same assumption).

References:

- apple docs about prewarm: https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431
- libSystem: https://github.com/apple-oss-distributions/Libsystem/blob/1abeb883382de8a03e6fc0534c03115892382293/init.c#L522-L558