### PR TITLE
server: Support rootless on iOS and tvOS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -147,6 +147,8 @@ if cc.get_define('FRIDA_VERSION') == ''
   cdata.set('FRIDA_NANO_VERSION', 0)
 endif
 
+cdata.set_quoted('FRIDA_PREFIX', get_option('prefix'))
+
 if host_os_family == 'windows'
   shlib_suffix = '.dll'
 elif host_os_family == 'darwin'

--- a/src/control-service.vala
+++ b/src/control-service.vala
@@ -50,7 +50,7 @@ namespace Frida {
 #endif
 #if DARWIN
 			host_session = new DarwinHostSession (new DarwinHelperBackend (), new TemporaryDirectory (),
-				opts.report_crashes);
+				opts.sysroot, opts.report_crashes);
 #endif
 #if LINUX
 			var tempdir = new TemporaryDirectory ();
@@ -860,6 +860,11 @@ namespace Frida {
 	}
 
 	public class ControlServiceOptions : Object {
+		public string? sysroot {
+			get;
+			set;
+		}
+
 		public bool enable_preload {
 			get;
 			set;

--- a/vapi/config.vapi
+++ b/vapi/config.vapi
@@ -1,5 +1,6 @@
 [CCode (lower_case_cprefix = "")]
 namespace Config {
+	public const string FRIDA_PREFIX;
 	public const string FRIDA_HELPER_PATH;
 	public const string FRIDA_AGENT_PATH;
 }


### PR DESCRIPTION
When built with external assets, detect when our program's filesystem path has been rebased, and look for frida-agent.dylib accordingly.