### PR TITLE
Fallback to "slower"  read_memory/write_memory on old Linux kernel

### DIFF
--- a/src/linux/frida-helper-backend.vala
+++ b/src/linux/frida-helper-backend.vala
@@ -2141,10 +2141,9 @@ namespace Frida {
 				ssize_t res = process_vm_writev (pid, (Posix.iovector[]) &local, (Posix.iovector[]) &remote, 0);
 				if (res != -1)
 					return;
-				if (errno == Posix.ENOSYS) {
-					// The kernel does not implement the syscall, we avoid to use it by resetting the function pointer.
+				if (errno == Posix.ENOSYS)
 					process_vm_writev = null;
-				} else if (errno != Posix.EPERM && errno != Posix.EFAULT)
+				else if (errno != Posix.EPERM && errno != Posix.EFAULT)
 					throw new Error.NOT_SUPPORTED ("Unable to write to process memory: %s", strerror (errno));
 			}
 #endif

--- a/src/linux/frida-helper-backend.vala
+++ b/src/linux/frida-helper-backend.vala
@@ -2105,7 +2105,10 @@ namespace Frida {
 				ssize_t res = process_vm_readv (pid, (Posix.iovector[]) &local, (Posix.iovector[]) &remote, 0);
 				if (res != -1)
 					return result;
-				if (errno != Posix.EPERM)
+				if (errno == Posix.ENOSYS) {
+					// The kernel doesn't implement the syscall, we avoid to use it by resetting the function pointer.
+					process_vm_readv = null;
+				} else if (errno != Posix.EPERM)
 					throw new Error.NOT_SUPPORTED ("Unable to read from process memory: %s", strerror (errno));
 			}
 
@@ -2139,7 +2142,10 @@ namespace Frida {
 				ssize_t res = process_vm_writev (pid, (Posix.iovector[]) &local, (Posix.iovector[]) &remote, 0);
 				if (res != -1)
 					return;
-				if (errno != Posix.EPERM && errno != Posix.EFAULT)
+				if (errno == Posix.ENOSYS) {
+					// The kernel does not implement the syscall, we avoid to use it by resetting the function pointer.
+					process_vm_writev = null;
+				} else if (errno != Posix.EPERM && errno != Posix.EFAULT)
 					throw new Error.NOT_SUPPORTED ("Unable to write to process memory: %s", strerror (errno));
 			}
 #endif

--- a/src/linux/frida-helper-backend.vala
+++ b/src/linux/frida-helper-backend.vala
@@ -2105,10 +2105,9 @@ namespace Frida {
 				ssize_t res = process_vm_readv (pid, (Posix.iovector[]) &local, (Posix.iovector[]) &remote, 0);
 				if (res != -1)
 					return result;
-				if (errno == Posix.ENOSYS) {
-					// The kernel doesn't implement the syscall, we avoid to use it by resetting the function pointer.
+				if (errno == Posix.ENOSYS)
 					process_vm_readv = null;
-				} else if (errno != Posix.EPERM)
+				else if (errno != Posix.EPERM)
 					throw new Error.NOT_SUPPORTED ("Unable to read from process memory: %s", strerror (errno));
 			}
 


### PR DESCRIPTION
## Issue

We faced some issues when launching a frida-server on a x86_64 box with an old Linux Kernel. The syscalls `process_vm_readv` and `process_vm_writev` exist but are not implemented.
Therefore, using those syscalls fail and the error ENOSYS is returned.

## Fix

We allow the linux backend to fallback to the slower implementation of  `read_memory`/`write_memory` when it faces this issue.
To avoid reaching this same issue at each call to `read_memory`/`write_memory`, we set the `process_vm_readv/process_vm_writev` function pointers to null to fallback directly to the "unoptimized" path.
