### PR TITLE
Revert "Add g_set_prgname() to frida_init() (#235)"

### DIFF
--- a/src/frida-glue.c
+++ b/src/frida-glue.c
@@ -40,8 +40,6 @@ frida_init_with_runtime (FridaRuntime rt)
     g_io_module_openssl_register ();
 #endif
 
-    g_set_prgname ("frida");
-
     if (runtime == FRIDA_RUNTIME_OTHER)
     {
       main_context = g_main_context_ref (g_main_context_default ());


### PR DESCRIPTION
This reverts commit 98e531b97ea5e8305ca3391fdcd29990e87d8cd4.

Before:
```
$ frida-server -h
Usage:
  frida [OPTION?]
...
```
```
$ frida-inject -h
Usage:
  frida [OPTION?]
...
```
After:
```
$ frida-server -h
Usage:
  frida-server [OPTION?]
...
```
```
$ frida-inject -h
Usage:
  frida-inject [OPTION?]
...
```

The bug described in https://github.com/frida/frida-core/issues/235#issuecomment-1845825617 was solved in https://github.com/frida/glib/commit/bf2a10211b3d3896943bac2010197b0728a32fac.