### PR TITLE
Add entitlements to allow read and execute cdhash

### DIFF
--- a/server/frida-server.xcent
+++ b/server/frida-server.xcent
@@ -355,5 +355,9 @@
 	<true/>
 	<key>com.apple.private.skip-library-validation</key>
 	<true/>
+	<key>com.apple.private.amfi.can-load-cdhash</key>
+	<true/>
+	<key>com.apple.private.amfi.can-execute-cdhash</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Adds  `com.apple.private.amfi.can-load-cdhash` and `com.apple.private.amfi.can-execute-cdhash` entitlements required to remap binaries in memory on iOS 16.