### PR TITLE
Better errors on generate-script-runtime

### DIFF
--- a/src/barebone/generate-script-runtime.py
+++ b/src/barebone/generate-script-runtime.py
@@ -25,11 +25,15 @@ def generate_runtime(input_dir, output_dir):
     try:
         subprocess.run([npm, "install"], capture_output=True, cwd=output_dir, check=True)
     except Exception as e:
+        if hasattr(e, "stderr") and e.stderr != b"":
+            info = e.stderr.decode()
+        else:
+            info = str(e)
         message = "\n".join([
             "",
             "***",
             "Failed to bootstrap the Barebone backend script runtime:",
-            "\t" + str(e),
+            "\t" + info,
             "It appears Node.js is not installed.",
             "We need it for processing JavaScript code at build-time.",
             "Check PATH or set NPM to the absolute path of your npm binary.",


### PR DESCRIPTION
This drove me nuts. I kept getting an error telling me npm wasn't installed. Turns out it was and the error was completely lying to me and not even showing me the true error.

With real errors, i get something more useful:
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@frida/crosspath@3.0.0',
npm WARN EBADENGINE   required: { node: '>=14.9.0' },
npm WARN EBADENGINE   current: { node: 'v12.22.9', npm: '8.5.1' }
npm WARN EBADENGINE }
file:///home/user/frida/build/tmp-linux-x86_64/frida-core/src/barebone/node_modules/frida-compile/dist/system/node.js:68
        defaultWatchFileKind: () => nodeSystem.defaultWatchFileKind?.(),
```

Also should probably update install instructions if noode > 14.9 is required, since by default npm on ubuntu 22.04 is apparently too old.