### PR TITLE
fruity: Fix adapter FirstUnicastAddress is NULL

### DIFF
--- a/src/fruity/device-monitor-windows.c
+++ b/src/fruity/device-monitor-windows.c
@@ -121,14 +121,15 @@ _frida_fruity_windows_pairing_browser_enumerate_network_interfaces (FridaFruityW
 
   for (adapter = adapters; adapter != NULL; adapter = adapter->Next)
   {
-    if (adapter->FirstUnicastAddress == NULL)
-      continue;
-
-    SOCKET_ADDRESS * raw_addr = &adapter->FirstUnicastAddress->Address;
+    SOCKET_ADDRESS * raw_addr;
     GInetSocketAddress * addr;
 
     if (adapter->IfType == IF_TYPE_SOFTWARE_LOOPBACK)
       continue;
+
+    if (adapter->FirstUnicastAddress == NULL)
+      continue;
+    raw_addr = &adapter->FirstUnicastAddress->Address;
 
     addr = G_INET_SOCKET_ADDRESS (g_socket_address_new_from_native (raw_addr->lpSockaddr, raw_addr->iSockaddrLength));
 

--- a/src/fruity/device-monitor-windows.c
+++ b/src/fruity/device-monitor-windows.c
@@ -129,8 +129,8 @@ _frida_fruity_windows_pairing_browser_enumerate_network_interfaces (FridaFruityW
 
     if (adapter->FirstUnicastAddress == NULL)
       continue;
-    raw_addr = &adapter->FirstUnicastAddress->Address;
 
+    raw_addr = &adapter->FirstUnicastAddress->Address;
     addr = G_INET_SOCKET_ADDRESS (g_socket_address_new_from_native (raw_addr->lpSockaddr, raw_addr->iSockaddrLength));
 
     func (adapter->IfIndex, adapter->AdapterName, addr, func_target);

--- a/src/fruity/device-monitor-windows.c
+++ b/src/fruity/device-monitor-windows.c
@@ -121,6 +121,9 @@ _frida_fruity_windows_pairing_browser_enumerate_network_interfaces (FridaFruityW
 
   for (adapter = adapters; adapter != NULL; adapter = adapter->Next)
   {
+    if (adapter->FirstUnicastAddress == NULL)
+      continue;
+
     SOCKET_ADDRESS * raw_addr = &adapter->FirstUnicastAddress->Address;
     GInetSocketAddress * addr;
 


### PR DESCRIPTION
Some virtual TUN adapter's FirstUnicastAddress is NULL, such as the Tunnel created by Clash, which will cause frida to crash when listing available devices.

<img width="1764" alt="SCR-20240723-kxgd-2" src="https://github.com/user-attachments/assets/8e9e4d15-256f-4f43-b1ad-45035d70247f">
