### PR TITLE
Fix null dereference in frida-server at startup

### DIFF
--- a/lib/netif/tunnel-interface-observer.vala
+++ b/lib/netif/tunnel-interface-observer.vala
@@ -30,11 +30,16 @@ public class Frida.TunnelInterfaceObserver : Object, DynamicInterfaceObserver {
 		context.info = this;
 		store = new Darwin.SystemConfiguration.DynamicStore (null, CoreFoundation.String.make ("Frida"),
 			on_interfaces_changed_wrapper, context);
+
 		var pattern = CoreFoundation.String.make ("State:/Network/Interface/utun.*/IPv6");
 		var patterns = new CoreFoundation.Array (null, ((CoreFoundation.Type[]) &pattern)[:1]);
 		store.set_notification_keys (null, patterns);
+
 		store.set_dispatch_queue (event_queue);
-		handle_interface_changes (store.copy_key_list (pattern));
+
+		var initial_keys = store.copy_key_list (pattern);
+		if (initial_keys != null)
+			handle_interface_changes (initial_keys);
 	}
 
 	private static void on_interfaces_changed_wrapper (Darwin.SystemConfiguration.DynamicStore store,


### PR DESCRIPTION
This happened on older iOS versions (happened to me on iPhone X on 16.1)

```
Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
Exception Subtype: KERN_INVALID_ADDRESS at 0x0000000000000000
Exception Codes: 0x0000000000000001, 0x0000000000000000

Triggered by Thread:  5


Thread 5 name:  gdbus
Thread 5 Crashed:
0   CoreFoundation                	       0x1968119d0 CFArrayGetCount + 8
1   frida-server                  	       0x104376164 frida_cf_array_iterator_construct + 92
2   frida-server                  	       0x1043779c4 frida_tunnel_interface_observer_handle_interface_changes + 92
3   frida-server                  	       0x104377868 frida_tunnel_interface_observer_real_start + 276
4   frida-server                  	       0x104372030 frida_web_service_do_start_co + 616
5   frida-server                  	       0x1043a9af8 g_task_return_now + 48
6   frida-server                  	       0x1043a9b38 complete_in_idle_cb + 20
7   frida-server                  	       0x104414cdc g_main_context_dispatch + 228
8   frida-server                  	       0x104414e9c g_main_context_iterate + 304
9   frida-server                  	       0x10441504c g_main_loop_run + 168
10  frida-server                  	       0x1043cd440 gdbus_shared_thread_func + 32
11  frida-server                  	       0x10442652c g_thread_proxy + 92
12  libsystem_pthread.dylib       	       0x1e2f48060 _pthread_start + 116
13  libsystem_pthread.dylib       	       0x1e2f46688 thread_start + 8

```

and prevented `frida-server` from starting up