### PR TITLE
linux/frida-helper-backend: handle process gone

### DIFF
--- a/src/linux/frida-helper-backend.vala
+++ b/src/linux/frida-helper-backend.vala
@@ -1933,9 +1933,8 @@ namespace Frida {
 				close ();
 			} catch (Error e) {
 				// If the process is gone, then there's no point in retrying.
-				if (e is Error.PROCESS_NOT_FOUND) {
+				if (e is Error.PROCESS_NOT_FOUND)
 					attach_state = ALREADY_ATTACHED;
-				}
 			} catch (GLib.Error e) {
 			}
 		}

--- a/src/linux/frida-helper-backend.vala
+++ b/src/linux/frida-helper-backend.vala
@@ -1931,6 +1931,11 @@ namespace Frida {
 			try {
 				yield suspend (null);
 				close ();
+			} catch (Error e) {
+				// If the process is gone, then there's no point in retrying.
+				if (e is Error.PROCESS_NOT_FOUND) {
+					attach_state = ALREADY_ATTACHED;
+				}
 			} catch (GLib.Error e) {
 			}
 		}


### PR DESCRIPTION
This is an attempt to handle the situation where the process has gone away and we're shutting down. I've observed the system looping attempting to move the state out of ATTACHED. It's possible that the state machine here needs to be made more complex (ALREADY_ATTACHED) is misleading.

Informs #478