### PR TITLE
Fix Compilation Errors due to Windows Encoding  Issues

### DIFF
--- a/compat/build.py
+++ b/compat/build.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 import argparse
 import base64
-import locale
 from collections import OrderedDict
 from dataclasses import dataclass, field
 import itertools
+import locale
 import os
 from pathlib import Path
 import pickle

--- a/compat/build.py
+++ b/compat/build.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import argparse
 import base64
+import locale
 from collections import OrderedDict
 from dataclasses import dataclass, field
 import itertools
@@ -400,7 +401,7 @@ def compile(privdir: Path, state: State):
                 **kwargs,
                 "stdout": subprocess.PIPE,
                 "stderr": subprocess.STDOUT,
-                "encoding": "utf-8",
+                "encoding": locale.getpreferredencoding(),
             }
         else:
             silenced_kwargs = kwargs


### PR DESCRIPTION
When I was compiling on windows, I got an error

`'utf-8' codec can't decode byte 0x90 in position 2:  invalid start byte"`
I looked at it because my windows system is gbk encoded, which is the encoding on many windows, and the frida-core compiler script is "utf-8" which caused this error, and when I modified it, the compiler worked fine.