### PR TITLE
Need to exclude the "shared" libc.so mapping

### DIFF
--- a/src/linux/frida-helper-backend.vala
+++ b/src/linux/frida-helper-backend.vala
@@ -3333,8 +3333,13 @@ namespace Frida {
 			var iter = MapsIter.for_pid (pid);
 			while (iter.next ()) {
 				string candidate_path = iter.path;
-				if (candidate_path == path)
+				if (candidate_path == path) {
+#if ANDROID
+					if (candidate_path == Gum.Process.query_libc_name () && iter.flags[3] == 's')
+						continue;
+#endif
 					return new ProcMapsEntry (iter.start_address, candidate_path, iter.identity);
+				}
 			}
 
 			return null;
@@ -3357,15 +3362,21 @@ namespace Frida {
 				}
 			}
 
-			public string identity {
+			public string flags {
 				owned get {
 					return info.fetch (3);
 				}
 			}
 
-			public string path {
+			public string identity {
 				owned get {
 					return info.fetch (4);
+				}
+			}
+
+			public string path {
+				owned get {
+					return info.fetch (5);
 				}
 			}
 
@@ -3380,8 +3391,8 @@ namespace Frida {
 					return;
 				}
 
-				if (!/^([0-9a-f]+)-([0-9a-f]+) \S{4} [0-9a-f]+ ([0-9a-f]{2,}:[0-9a-f]{2,} \d+) +([^\n]+)$/m.match (contents,
-						0, out info)) {
+				if (!/^([0-9a-f]+)-([0-9a-f]+) (\S{4}) [0-9a-f]+ ([0-9a-f]{2,}:[0-9a-f]{2,} \d+) +([^\n]+)$/m.match (
+						contents, 0, out info)) {
 					assert_not_reached ();
 				}
 			}


### PR DESCRIPTION
6e3e1cd000-6e3e2c7000 r--s 00000000 07:08 38                             /apex/com.android.runtime/lib64/bionic/libc.so
71eb6c2000-71eb6ff000 r--p 00000000 07:08 38                             /apex/com.android.runtime/lib64/bionic/libc.so
71eb6ff000-71eb781000 r-xp 0003d000 07:08 38                             /apex/com.android.runtime/lib64/bionic/libc.so
71eb781000-71eb786000 r--p 000bf000 07:08 38                             /apex/com.android.runtime/lib64/bionic/libc.so
71eb786000-71eb787000 rw-p 000c3000 07:08 38                             /apex/com.android.runtime/lib64/bionic/libc.so

the first line mapping of the http://libc.so, it's shared , we can't start from it, we need to start from the second line