### PR TITLE
fix iOS error "failed to open USB device: Input/Output Error"

### DIFF
--- a/src/fruity/device-monitor.vala
+++ b/src/fruity/device-monitor.vala
@@ -1030,6 +1030,11 @@ namespace Frida.Fruity {
 				}
 
 				unowned string udid = usb_device.udid;
+
+				// iPhones before iOS 17 on Windows are sometimes misdetected with an empty udid -> skip those devices
+				if (udid.length == 0)
+					return;
+
 				var transport = usb_transports.first_match (t => t.udid == udid);
 
 				bool may_need_time_to_settle = state != STARTING && (transport == null || transport.modeswitch_in_progress);


### PR DESCRIPTION
This PR fixes the issues:

* https://github.com/frida/frida/issues/3303
* https://github.com/frida/frida/issues/3278
* https://github.com/frida/frida/issues/3279
* https://github.com/frida/frida/issues/3283

As an Frida USB device with an empty `udid` should not occur with common iOS or Android devices I assume that it is safe to filter out such devices. 

@oleavr