### PR TITLE
Support more than ~8 ADB-connected devices

### DIFF
--- a/src/droidy/droidy-client.vala
+++ b/src/droidy/droidy-client.vala
@@ -791,7 +791,7 @@ namespace Frida.Droidy {
 		}
 
 		private const uint16 ADB_SERVER_DEFAULT_PORT = 5037;
-		private const uint16 MAX_MESSAGE_LENGTH = 1024;
+		private const uint16 MAX_MESSAGE_LENGTH = 65536;
 
 		public static async Client open (Cancellable? cancellable = null) throws Error, IOError {
 			SocketConnectable? connectable = null;


### PR DESCRIPTION
If more than around 8 devices are connected over ADB, frida doesn't see any ADB connected devices anymore. This fixes the issue (tested for around 40 devices). 