### PR TITLE
I cannot compile with my linux-arm-musl toolchain with lto enabled.

### DIFF
--- a/src/linux/helpers/Makefile
+++ b/src/linux/helpers/Makefile
@@ -15,7 +15,7 @@ crossfile := $(BUILDDIR)/frida-$(host_machine).txt
 
 build: ext/linux/tools/include/nolibc/nolibc.h
 	rm -rf build
-	$(MESON) setup --cross-file $(crossfile) -Db_lto=true build
+	$(MESON) setup --cross-file $(crossfile) -Db_lto=false build
 	$(MESON) compile -C build
 	cp build/bootstrapper.bin bootstrapper-$(host_arch).bin
 	cp build/loader.bin loader-$(host_arch).bin


### PR DESCRIPTION
I get:
../arm-linux-musleabihf/bin/ld: DWARF error: can't find .debug_ranges section. /tmp/ccEOssxO.ltrans0.ltrans.o: in function `frida_try_load_libc_and_raise': <artificial>:(.text+0x13b4): undefined reference to `memcpy' /home/user/dev/blog/frida-musl/cross/install/bin/../lib/gcc/arm-linux-musleabihf/14.2.0/../../../../arm-linux-musleabihf/bin/ld: <artificial>:(.text+0x14dc): undefined reference to `memcpy'

I tried a few things, and it's strange why there is a ref to memcpy. However excluding lto works. It appears that the footprint is not largely affected. I'll let Ole decide if this is for consideration

I do see that Ole said in another commit that armhf-musl will be included in CI; out of curiosity, which toolchain are you guys using for 32-bit armhf-musl?