### PR TITLE
network-stack: Always send enqueued data

### DIFF
--- a/src/fruity/network-stack.vala
+++ b/src/fruity/network-stack.vala
@@ -687,7 +687,7 @@ namespace Frida.Fruity {
 						if (available_space < len) {
 							len = available_space;
 							if (len == 0)
-								return OK;
+								break;
 						}
 
 						write_err = pcb.write (buffer[n:n + len], flags);


### PR DESCRIPTION
This change makes sure `pcb.output()` is called even when no more space is available on the queue, preventing stall.