### PR TITLE
network-stack: Reduce delay between writes

### DIFF
--- a/src/fruity/network-stack.vala
+++ b/src/fruity/network-stack.vala
@@ -584,7 +584,7 @@ namespace Frida.Fruity {
 			}
 
 			private bool pcb_is_writable () {
-				return pcb.query_send_buffer_space () > LWIP.Tcp.SEND_LOW_WATERMARK &&
+				return pcb.query_send_buffer_space () > 0 &&
 					pcb.query_send_queue_length () < LWIP.Tcp.SEND_QUEUE_LOW_WATERMARK;
 			}
 


### PR DESCRIPTION
By flagging as writable as soon as some space is available, without waiting for the low watermark.