### PR TITLE
fix: cleanup old GumJS API reference

### DIFF
--- a/src/darwin/agent/launchd.js
+++ b/src/darwin/agent/launchd.js
@@ -257,7 +257,7 @@ function findSubstrateLauncher() {
   if (Process.arch !== 'arm64')
     return null;
 
-  const imp = Module.enumerateImports('/sbin/launchd').filter(imp => imp.name === 'posix_spawn')[0];
+  const imp = Process.mainModule.enumerateImports().filter(imp => imp.name === 'posix_spawn')[0];
   if (imp === undefined)
     return null;
   const impl = imp.slot.readPointer().strip();

--- a/src/darwin/agent/launchd.js
+++ b/src/darwin/agent/launchd.js
@@ -257,7 +257,7 @@ function findSubstrateLauncher() {
   if (Process.arch !== 'arm64')
     return null;
 
-  const imp = Process.mainModule.enumerateImports().filter(imp => imp.name === 'posix_spawn')[0];
+  const imp = Process.mainModule.enumerateImports().find(imp => imp.name === 'posix_spawn');
   if (imp === undefined)
     return null;
   const impl = imp.slot.readPointer().strip();


### PR DESCRIPTION
Cleans up old GumJS apis. This specific PR focuses on solving "Attaching..." issue on jailbroken iOS, or more specifically
```
{"type":"error","description":"TypeError: not a function","stack":"TypeError: not a function\n    at findSubstrateLauncher (/internal-agent.js:260)\n    at applyJailbreakQuirks (/internal-agent.js:170)\n    at <eval> (/internal-agent.js:50)","fileName":"/internal-agent.js","lineNumber":260,"columnNumber":1}
```