### PR TITLE
compiler: Rename conflictful Go symbols in backend

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -363,11 +363,13 @@ if host_toolchain == 'microsoft'
   lib = find_program('lib')
   ar = ''
   nm = ''
+  ranlib = ''
   strip = ''
 else
   lib = ''
   ar = find_program('ar')
   nm = find_program('nm')
+  ranlib = find_program('ranlib')
   strip = find_program('strip')
 endif
 if host_os_family != 'windows'
@@ -424,6 +426,8 @@ if compiler_backend_opt.allowed()
         cc.get_id(),
         '>>>', cc.cmd_array(), '<<<',
         '>>>', ar, '<<<',
+        '>>>', nm, '<<<',
+        '>>>', ranlib, '<<<',
       ],
       capture: true,
       check: true

--- a/src/compiler/backend-glue.c
+++ b/src/compiler/backend-glue.c
@@ -3,11 +3,11 @@
 #include <glib.h>
 
 #ifdef HAVE_ARM64
-# define FRIDA_CGO_INIT_FUNC _rt0_arm64_windows_lib
+# define FRIDA_CGO_INIT_FUNC _st0_arm64_windows_lib
 #elif GLIB_SIZEOF_VOID_P == 8
-# define FRIDA_CGO_INIT_FUNC _rt0_amd64_windows_lib
+# define FRIDA_CGO_INIT_FUNC _st0_amd64_windows_lib
 #else
-# define FRIDA_CGO_INIT_FUNC rt0_386_windows_lib
+# define FRIDA_CGO_INIT_FUNC st0_386_windows_lib
 #endif
 
 extern void FRIDA_CGO_INIT_FUNC ();


### PR DESCRIPTION
To avoid conflicts when we're linked into a Go binary.