### PR TITLE
fruity: Workaround  lookup of short bundle IDs

### DIFF
--- a/src/fruity/fruity-host-session.vala
+++ b/src/fruity/fruity-host-session.vala
@@ -790,6 +790,8 @@ namespace Frida {
 			var query = new Fruity.PlistDict ();
 			var ids = new Fruity.PlistArray ();
 			ids.add_string (program);
+			ids.add_string ("");
+			ids.add_string ("");
 			query.set_array ("BundleIDs", ids);
 
 			var matches = yield installation_proxy.lookup (query, cancellable);


### PR DESCRIPTION
When a bundle ID of length < 4 is the only item of the `BundleIDs` array in an installation-proxy `Lookup` request *and* `Entitlements` is among the requested `ReturnAttributes` - the lookup request yields a 0-byte response, leading to Frida throwing `Connection closed` and effectively preventing jailed spawn of apps with such bundle IDs.

This workaround adds two empty bundle IDs to the request, which have no effects on the result apart from removing this weird threshold-like behaviour, allowing the requests to succeed.

One empty ID is enough to support bundle IDs of length 3, two empty IDs are what takes to make 1-char bundle IDs go through.