### PR TITLE
Be

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,6 +423,7 @@ jobs:
     strategy:
       matrix:
         arch: [x86, x86_64, arm, armbe8, arm64, arm64be, arm64beilp32, mips, mipsel, mips64, mips64el]
+      fail-fast: false
     runs-on: ubuntu-latest
     container: ghcr.io/frida/core-linux-helpers-${{ matrix.arch }}:latest
     steps:
@@ -436,7 +437,7 @@ jobs:
       - name: Check for unexpected changes
         run: |
           git config --global --add safe.directory "$(realpath .)"
-          status_output="$(git status --porcelain)"
+          status_output=$(git status --porcelain tests/labrats/{resident-agent,simple-agent}-linux-${{ matrix.arch }}.so tests/labrats/{forker,sleeper,spawner}-linux-${{ matrix.arch }})
           if [ -n "$status_output" ]; then
             echo "Unexpected changes detected:"
             echo "$status_output"
@@ -455,6 +456,7 @@ jobs:
     strategy:
       matrix:
         arch: [x86, x86_64, arm, armbe8, arm64, arm64be, arm64beilp32, mips, mipsel, mips64, mips64el]
+      fail-fast: false
     runs-on: ubuntu-latest
     container: ghcr.io/frida/core-linux-helpers-${{ matrix.arch }}:latest
     steps:
@@ -468,7 +470,7 @@ jobs:
       - name: Check for unexpected changes
         run: |
           git config --global --add safe.directory "$(realpath .)"
-          status_output="$(git status --porcelain)"
+          status_output=$(git status --porcelain src/linux/helpers/{bootstrapper,loader}-${{ matrix.arch }}.bin)
           if [ -n "$status_output" ]; then
             echo "Unexpected changes detected:"
             echo "$status_output"

--- a/src/linux/helpers/rebuild.sh
+++ b/src/linux/helpers/rebuild.sh
@@ -84,12 +84,6 @@ build_arch () {
     export CC="gcc -m32" CXX="g++ -m32" STRIP="strip"
   fi
 
-  case "$ARCH" in
-  armbe8 | arm64be | arm64beilp32)
-    EXTRA_FLAGS+=("--without-prebuilds=sdk:host")
-    ;;
-  esac
-
   cd "$FRIDA_CORE_DIR"
 
   rm -rf "$BUILD_DIR"

--- a/tests/labrats/rebuild.sh
+++ b/tests/labrats/rebuild.sh
@@ -77,12 +77,6 @@ build_arch () {
     export CC="gcc -m32" CXX="g++ -m32" STRIP="strip"
   fi
 
-  case "$ARCH" in
-  armbe8 | arm64be | arm64beilp32)
-    EXTRA_FLAGS+=("--without-prebuilds=sdk:host")
-    ;;
-  esac
-
   cd "$FRIDA_CORE_DIR"
 
   rm -rf "$BUILD_DIR"

--- a/tests/test-host-session.vala
+++ b/tests/test-host-session.vala
@@ -1557,7 +1557,7 @@ namespace Frida.HostSessionTest {
 		private static async void spawn (Harness h) {
 			if (!GLib.Test.slow () && (
 						Frida.Test.os () == Frida.Test.OS.ANDROID ||
-						Frida.Test.os_arch_suffix () == "-linux-arm" ||
+						Frida.Test.os_arch_suffix () == "-linux-armbe8" ||
 						Frida.Test.os_arch_suffix () == "-linux-arm64be"
 					)) {
 				stdout.printf ("<skipping, run in slow mode> ");


### PR DESCRIPTION
* Fix the CI builds of labrats and helpers to only check the architecture that they are building.
* Use the prebuilt SDK for `armbe8`, `arm64be` and `arm64beilp32`
* Fix the disabling of a test which is supposed to be disabled in `armbe8` rather than `arm`