### PR TITLE
Compiler/remove types

### DIFF
--- a/src/compiler/build-backend.py
+++ b/src/compiler/build-backend.py
@@ -41,7 +41,17 @@ def build_backend(
         dest.parent.mkdir(exist_ok=True)
         shutil.copy(f, dest)
 
+    replacer_inputs: List[Path] = [
+            Path(priv_dir / "symbol-replacer" / "main.go"),
+    ]
+
+    symbol_dest = priv_dir / "symbol-replacer"
+    symbol_dest.mkdir(exist_ok=True)
+    shutil.copy(base_dir / "symbol-replacer" / "main.go", symbol_dest)
+    shutil.copy(base_dir / "symbol-replacer" / "go.mod", symbol_dest)
+
     go_sources = [str(f.relative_to(base_dir)) for f in inputs if f.suffix == ".go"]
+    symbol_replacer_sources = [str("symbol-replacer" / f.relative_to(symbol_dest)) for f in replacer_inputs if f.suffix == ".go"]
 
     def run(*args):
         return subprocess.run(
@@ -60,6 +70,8 @@ def build_backend(
     backend_a = priv_dir / "frida-compiler-backend.a"
     backend_h = priv_dir / "frida-compiler-backend.h"
 
+    symbol_replacer = symbol_dest / "frida-symbol-replacer"
+
     run(
         go,
         "build",
@@ -71,8 +83,25 @@ def build_backend(
         *go_sources,
     )
 
-    symbols_to_scramble = detect_conflictful_symbols_in_archive(backend_a, config["nm"])
-    scramble_symbols_in_archive(backend_a, symbols_to_scramble, config["ranlib"])
+    # when we are cross-compiling we want to unset GOOS and GOARCH
+    env_copy = config["env"].copy()
+    env_copy["GOOS"] = ""
+    env_copy["GOARCH"] = ""
+
+    subprocess.run([go,
+        "build",
+        "-o",
+        symbol_replacer.name,
+        *symbol_replacer_sources],
+        cwd=priv_dir,
+        env=env_copy,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        encoding="utf-8",
+        check=True,
+    )
+
+    pr = run(priv_dir / symbol_replacer.name, backend_a.name, *config["nm"], *config["ranlib"])
 
     if (mingw := config.get("mingw")) is not None and (abi := config["abi"]) in {
         "x86",
@@ -98,6 +127,7 @@ def build_backend(
                 "gdtoa",
                 "gmisc",
                 "mingw_fprintf",
+                "mingw_vprintf",
                 "mingw_pformat",
                 "misc",
             ]
@@ -114,50 +144,6 @@ def build_backend(
 
     shutil.copy(priv_dir / backend_a.name, output_dir / backend_a.name)
     shutil.copy(priv_dir / backend_h.name, output_dir / backend_h.name)
-
-
-def detect_conflictful_symbols_in_archive(
-    archive: Path, nm_cmd_array: List[str]
-) -> List[str]:
-    result = []
-    for line in subprocess.run(
-        [*nm_cmd_array, str(archive)], capture_output=True, encoding="utf-8", check=True
-    ).stdout.splitlines():
-        tokens = line.lstrip().split(" ")
-        if len(tokens) >= 3 and tokens[1] in {"S", "T"}:
-            symbol = tokens[2]
-            if all(sub not in symbol for sub in ("/", ".", ":", "frida")):
-                result.append(symbol)
-    return result
-
-
-def scramble_symbols_in_archive(
-    archive: Path, symbols: List[str], ranlib_cmd_array: List[str]
-):
-    data = archive.read_bytes()
-
-    for old_sym in symbols:
-        new_sym = roll_first_alpha(old_sym)
-        data = data.replace(old_sym.encode("ascii"), new_sym.encode("ascii"))
-
-    archive.write_bytes(data)
-
-    subprocess.run([*ranlib_cmd_array, str(archive)], check=True)
-
-
-def roll_first_alpha(s: str) -> str:
-    chars = list(s)
-    for i, c in enumerate(chars):
-        if c.isalpha():
-            if c == "z":
-                chars[i] = "a"
-            elif c == "Z":
-                chars[i] = "A"
-            else:
-                chars[i] = chr(ord(c) + 1)
-            break
-    return "".join(chars)
-
 
 # Work around the Go toolchain's almost-MSVC-compatible object files
 # until our patch is merged upstream:

--- a/src/compiler/build-backend.py
+++ b/src/compiler/build-backend.py
@@ -127,7 +127,6 @@ def build_backend(
                 "gdtoa",
                 "gmisc",
                 "mingw_fprintf",
-                "mingw_vprintf",
                 "mingw_pformat",
                 "misc",
             ]

--- a/src/compiler/symbol-replacer/go.mod
+++ b/src/compiler/symbol-replacer/go.mod
@@ -1,0 +1,3 @@
+module github.com/frida/frida-symbol-replacer
+
+go 1.24.4

--- a/src/compiler/symbol-replacer/main.go
+++ b/src/compiler/symbol-replacer/main.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+	"unicode"
+)
+
+var (
+	typeRegex = regexp.MustCompile(`type:.eq.(\[\d+\])?([a-z].*)`)
+)
+
+type symbl struct {
+	symType string
+	symVal  string
+}
+
+func main() {
+	archive := os.Args[1]
+	nm := os.Args[2]
+	ranlib := strings.Join(os.Args[3:], " ")
+
+	buf := new(bytes.Buffer)
+	c := exec.Command(nm, archive)
+	c.Stdout = buf
+	if err := c.Run(); err != nil {
+		panic(err)
+	}
+
+	symbols := make(map[string][]string)
+	outch := make(chan *symbl, 100)
+	inch := make(chan string, 100)
+	done := make(chan struct{})
+
+	go func() {
+		for s := range outch {
+			symbols[s.symType] = append(symbols[s.symType], s.symVal)
+		}
+		done <- struct{}{}
+	}()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go parse(inch, outch, &wg)
+	}
+
+	content := strings.Split(buf.String(), "\n")
+	for _, line := range content {
+		splitted := strings.Split(line, " ")
+		if len(splitted) >= 3 {
+			if strings.ContainsAny(splitted[1], "TSt") {
+				inch <- splitted[2]
+			}
+		}
+	}
+	close(inch)
+
+	wg.Wait()
+	close(outch)
+	<-done
+
+	f, err := os.OpenFile(archive, os.O_RDWR, 0755)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	data, _ := io.ReadAll(f)
+
+	for tp, syms := range symbols {
+		for _, symbol := range syms {
+			switch tp {
+			case "simple":
+				data = bytes.ReplaceAll(data, []byte(symbol), []byte(flipAlpha(symbol)))
+			case "typed":
+				toReplace := "type:.eq." + symbol
+				splitted := strings.Split(symbol, "=>")
+				if len(splitted) == 1 {
+					data = bytes.ReplaceAll(data, []byte(toReplace), []byte("type:.eq."+flipAlpha(symbol)))
+				} else {
+					toReplace = "type:.eq." + splitted[0] + splitted[1]
+					flipped := flipAlpha(splitted[1])
+					data = bytes.ReplaceAll(data, []byte(toReplace), []byte("type:.eq."+splitted[0]+flipped))
+					data = bytes.ReplaceAll(data, []byte(splitted[1]), []byte(flipped))
+				}
+			}
+		}
+	}
+
+	data = bytes.ReplaceAll(data, []byte("mingw_vgprintf"), []byte("mingw_vfprintf"))
+
+	f.Truncate(0)
+	f.Seek(0, 0)
+	f.Write(data)
+
+	ranl := exec.Command(ranlib, archive)
+	if err := ranl.Run(); err != nil {
+		panic(err)
+	}
+}
+
+func flipAlpha(s string) string {
+	dt := []byte(s)
+	for i, r := range s {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) {
+			if r == 'z' {
+				dt[i] = 'a'
+			} else if r == 'Z' {
+				dt[i] = 'A'
+			} else {
+				dt[i] = byte(r + 1)
+			}
+			break
+		}
+	}
+	return string(dt)
+}
+
+func parse(inch chan string, outch chan *symbl, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for symbol := range inch {
+		if !strings.ContainsAny(symbol, "/.:") && !strings.Contains(symbol, "frida") {
+			outch <- &symbl{symType: "simple", symVal: symbol}
+		}
+		if strings.Contains(symbol, "type:.eq.") {
+			matches := typeRegex.FindStringSubmatch(symbol)
+			if len(matches) > 0 {
+				val := strings.Join(matches[1:], "=>")
+				outch <- &symbl{symType: "typed", symVal: val}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR adds more symbol replacements that goes along with commit https://github.com/frida/frida-core/commit/375be6181a166a313d6d63d59c86525e44b578f0.

Additionally, this replaces weird `mingw_wgprintf` symbol that is nowhere defined, so it gets replaced with `mingw_vfprintf`. This is needed in order to allow CGO binaries to link with `libfrida-core.a` cross-compiled on Linux for Windows using mingw.