### PR TITLE
compiler: fix error reading shim files

### DIFF
--- a/src/compiler/shims.go
+++ b/src/compiler/shims.go
@@ -18,6 +18,7 @@ export { default as process } from 'node:process';
 //go:embed node_modules/@frida/*/package.json
 //go:embed node_modules/@frida/*/*.js
 //go:embed node_modules/@frida/*/*/*.js
+//go:embed node_modules/@frida/*/*/*/*.js
 //go:embed node_modules/frida-fs/package.json
 //go:embed node_modules/frida-fs/*/*.js
 var embeddedShims embed.FS


### PR DESCRIPTION
Previously, embeddedShims can only reach source files with maximum depth of 2. Which will result in errors like:

open node_modules/@frida/assert/internal/util/comparisons.js: file does not exist

This update allows matching such files.

I have compiled and tested the modified frida compiler. 