### PR TITLE
agent: hotfix NativeBridge to stop Exceptor from hooking libc

### DIFF
--- a/lib/agent/agent.vala
+++ b/lib/agent/agent.vala
@@ -1400,12 +1400,12 @@ namespace Frida.Agent {
 				if (nb_api.unload_library == null)
 					parameters.append ("|eternal|sticky");
 				/*
-				 * Disable ExitMonitor and Exceptor to work around a bug in Android's libndk_translation.so on Android 11.
-				 * We need to avoid modifying libc.so ranges that the translator potentially depends on, to
-				 * avoid blowing up when Interceptor's CPU cache flush results in the translated code being
-				 * discarded, which seems like an edge-case the translator doesn't handle.
+				 * Disable Exceptor and ExitMonitor to work around a bug in Android's libndk_translation.so
+				 * on Android 11. We need to avoid modifying libc.so ranges that the translator potentially
+				 * depends on, to avoid blowing up when Interceptor's CPU cache flush results in the translated
+				 * code being discarded, which seems like an edge-case the translator doesn't handle.
 				 */
-				parameters.append ("|exit-monitor:off|exceptor:off");
+				parameters.append ("|exceptor:off|exit-monitor:off");
 
 				emulated_bridge_state = new BridgeState (parameters.str);
 


### PR DESCRIPTION
Exceptor needs to hook `signal` and `sigaction`, but they are in `libc` leading to `gum_mprotect` aborting because it cannot change `libc`'s `r--`.

I tested on AVD with Android 14 and 15 and it prevents the crash observed in the upstream version when using `frida-server` or `frida-inject`.