### PR TITLE
meson: clarify that frida's vala needs to be built with meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,7 @@ Vala sources from:
 
     https://github.com/frida/vala
 
-and compile them with meson.''')
+and compile them with Meson.''')
 endif
 
 c_languages = ['c', 'cpp']

--- a/meson.build
+++ b/meson.build
@@ -12,9 +12,11 @@ if not meson.get_compiler('vala').version().endswith('-frida')
   error('''Incompatible Vala compiler detected.
 
 Frida currently relies on features not yet upstream. Grab the Frida-optimized
-Vala compiler from:
+Vala sources from:
 
-    https://github.com/frida/vala''')
+    https://github.com/frida/vala
+
+and compile them with meson.''')
 endif
 
 c_languages = ['c', 'cpp']


### PR DESCRIPTION
The vala README only mentions autoconf&make instructions, and when vala is compiled that way the -frida suffix is not added to the version string, and the frida-core check for vala fails.

Therefore, clarify that vala needs to be built from source with meson.

See also complementary PR in vala: https://github.com/frida/vala/pull/7