### PR TITLE
fruity: Get away with killing prewarmed target

### DIFF
--- a/src/fruity/fruity-host-session.vala
+++ b/src/fruity/fruity-host-session.vala
@@ -808,7 +808,10 @@ namespace Frida {
 			var lldb = yield start_lldb_service (cancellable);
 			var process = yield lldb.launch (argv, launch_options, cancellable);
 			if (process.observed_state == ALREADY_RUNNING) {
-				yield lldb.kill (cancellable);
+				try {
+					yield lldb.kill (cancellable);
+				} catch (Error e) {
+				}
 				yield lldb.close (cancellable);
 
 				lldb = yield start_lldb_service (cancellable);


### PR DESCRIPTION
Killing a prewarmed process at spawn time results in a "connection closed" error. This change catches it so it's possible to go on and spawn a fresh instance.