### PR TITLE
platform: add support for VisionOS

### DIFF
--- a/lib/base/session-glue.c
+++ b/lib/base/session-glue.c
@@ -30,7 +30,7 @@ _frida_query_windows_computer_name (void)
   return g_utf16_to_utf8 (buffer, -1, NULL, NULL, NULL);
 }
 
-#elif defined (HAVE_IOS) || defined (HAVE_TVOS)
+#elif defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <dlfcn.h>

--- a/lib/base/session.vala
+++ b/lib/base/session.vala
@@ -1952,6 +1952,8 @@ namespace Frida {
 		id = "watchos";
 #elif TVOS
 		id = "tvos";
+#elif XROS
+		id = "xros";
 #elif ANDROID
 		id = "android";
 #elif FREEBSD

--- a/lib/gadget/gadget-darwin.m
+++ b/lib/gadget/gadget-darwin.m
@@ -29,7 +29,7 @@ frida_gadget_environment_detect_bundle_name (void)
 gchar *
 frida_gadget_environment_detect_documents_dir (void)
 {
-#if defined (HAVE_IOS) || defined (HAVE_TVOS)
+#if defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
   @autoreleasepool
   {
     NSArray<NSString *> * paths = NSSearchPathForDirectoriesInDomains (NSDocumentDirectory, NSUserDomainMask, YES);

--- a/server/meson.build
+++ b/server/meson.build
@@ -6,7 +6,7 @@ server_sources = [
 if host_os_family == 'darwin'
   server_sources += ['server-darwin.m']
 endif
-if host_os in ['ios', 'tvos']
+if host_os in ['ios', 'tvos', 'xros']
   server_sources += [
     'server-ios-tvos.c',
   ]

--- a/server/server-glue.c
+++ b/server/server-glue.c
@@ -1,7 +1,7 @@
 #include "server-glue.h"
 
 #include "frida-core.h"
-#if defined (HAVE_IOS) || defined (HAVE_TVOS)
+#if defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
 # include "server-ios-tvos.h"
 #endif
 #ifdef HAVE_ANDROID
@@ -54,7 +54,7 @@ frida_server_environment_set_verbose_logging_enabled (gboolean enabled)
 void
 frida_server_environment_configure (void)
 {
-#if defined (HAVE_IOS) || defined (HAVE_TVOS)
+#if defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
   _frida_server_ios_tvos_configure ();
 #endif
 

--- a/src/darwin/frida-helper-backend-glue.m
+++ b/src/darwin/frida-helper-backend-glue.m
@@ -80,7 +80,7 @@
     goto bsd_failure; \
   }
 
-#if defined (HAVE_IOS) || defined (HAVE_TVOS)
+#if defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
 # define CORE_FOUNDATION "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
 #else
 # define CORE_FOUNDATION "/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation"
@@ -390,7 +390,7 @@ static gboolean frida_spawn_instance_is_libc_initialized (FridaSpawnInstance * s
 static void frida_spawn_instance_set_libc_initialized (FridaSpawnInstance * self);
 static kern_return_t frida_spawn_instance_create_dyld_data (FridaSpawnInstance * self);
 static void frida_spawn_instance_destroy_dyld_data (FridaSpawnInstance * self);
-#if defined (HAVE_IOS) || defined (HAVE_TVOS)
+#if defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
 static gboolean frida_pick_ios_tvos_bootstrapper (GumModule * module, gpointer user_data);
 #endif
 static void frida_spawn_instance_unset_helpers (FridaSpawnInstance * self);
@@ -971,7 +971,7 @@ invalid_pid:
   }
 }
 
-#if defined (HAVE_IOS) || defined (HAVE_TVOS)
+#if defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
 
 #import "springboard.h"
 
@@ -2669,7 +2669,7 @@ frida_inject_instance_on_mach_thread_dead (void * context)
 
     self->agent_context->posix_thread = MACH_PORT_NULL;
 
-#if defined (HAVE_IOS) || defined (HAVE_TVOS)
+#if defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
     port_might_be_guarded = gum_darwin_check_xnu_version (7938, 0, 0);
 #else
     port_might_be_guarded = FALSE;
@@ -3284,7 +3284,7 @@ next_phase:
       return TRUE;
 
     case FRIDA_BREAKPOINT_DLOPEN_BOOTSTRAPPER:
-#if defined (HAVE_IOS) || defined (HAVE_TVOS)
+#if defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
       if (self->bootstrapper_name != 0)
       {
         frida_spawn_instance_set_libc_initialized (self);
@@ -3577,7 +3577,7 @@ frida_spawn_instance_create_dyld_data (FridaSpawnInstance * self)
   if (!gum_darwin_query_ptrauth_support (self->task, &ptrauth_support))
     return KERN_FAILURE;
 
-#if defined (HAVE_IOS) || defined (HAVE_TVOS)
+#if defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
   gum_darwin_enumerate_modules (self->task, frida_pick_ios_tvos_bootstrapper, &data);
 #endif
 
@@ -3655,7 +3655,7 @@ frida_spawn_instance_destroy_dyld_data (FridaSpawnInstance * self)
   self->dyld_data = 0;
 }
 
-#if defined (HAVE_IOS) || defined (HAVE_TVOS)
+#if defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
 
 static gboolean
 frida_pick_ios_tvos_bootstrapper (GumModule * module, gpointer user_data)
@@ -5449,7 +5449,7 @@ frida_set_hardware_single_step (gpointer debug_state, GumDarwinUnifiedThreadStat
 static gboolean
 frida_is_hardware_breakpoint_support_working (void)
 {
-#if defined (HAVE_IOS) || defined (HAVE_TVOS)
+#if defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
   static gsize cached_result = 0;
 
   if (g_once_init_enter (&cached_result))

--- a/src/darwin/policy-softener-glue.c
+++ b/src/darwin/policy-softener-glue.c
@@ -1,6 +1,6 @@
 #include "frida-helper-backend.h"
 
-#if defined (HAVE_IOS) || defined (HAVE_TVOS)
+#if defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
 # include "policyd.h"
 # include "substituted-client.h"
 # include "substituted2-client.h"

--- a/src/darwin/system-darwin.m
+++ b/src/darwin/system-darwin.m
@@ -16,11 +16,11 @@
 # endif
 #endif
 
-#if defined (HAVE_IOS) || defined (HAVE_TVOS)
+#if defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
 # import "springboard.h"
 #endif
 
-#if defined (HAVE_WATCHOS) || defined (HAVE_TVOS)
+#if defined (HAVE_WATCHOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
 # import <Foundation/Foundation.h>
 #endif
 
@@ -35,7 +35,7 @@ struct _FridaEnumerateApplicationsOperation
 {
   FridaScope scope;
   GHashTable * process_by_identifier;
-#if defined (HAVE_IOS) || defined (HAVE_TVOS)
+#if defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
   FridaSpringboardApi * api;
 #endif
 
@@ -45,14 +45,14 @@ struct _FridaEnumerateApplicationsOperation
 struct _FridaEnumerateProcessesOperation
 {
   FridaScope scope;
-#if defined (HAVE_IOS) || defined (HAVE_TVOS)
+#if defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
   FridaSpringboardApi * api;
 #endif
 
   GArray * result;
 };
 
-#if defined (HAVE_IOS) || defined (HAVE_TVOS)
+#if defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
 static void frida_collect_application_info_from_id_cstring (const gchar * identifier, FridaEnumerateApplicationsOperation * op);
 static void frida_collect_application_info_from_id_nsstring (NSString * identifier, FridaEnumerateApplicationsOperation * op);
 #endif
@@ -60,13 +60,13 @@ static void frida_collect_application_info_from_id_nsstring (NSString * identifi
 static void frida_collect_process_info_from_pid (guint pid, FridaEnumerateProcessesOperation * op);
 static void frida_collect_process_info_from_kinfo (struct kinfo_proc * process, FridaEnumerateProcessesOperation * op);
 
-#if defined (HAVE_MACOS) || defined (HAVE_IOS) || defined (HAVE_TVOS)
+#if defined (HAVE_MACOS) || defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
 static void frida_add_app_id (GHashTable * parameters, NSString * identifier);
 #endif
 
 #if defined (HAVE_MACOS)
 static void frida_add_app_icons (GHashTable * parameters, NSImage * image);
-#elif defined (HAVE_IOS) || defined (HAVE_TVOS)
+#elif defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
 static void frida_add_app_metadata (GHashTable * parameters, NSString * identifier, FridaSpringboardApi * api);
 static void frida_add_app_state (GHashTable * parameters, guint pid, FridaSpringboardApi * api);
 static void frida_add_app_icons (GHashTable * parameters, NSString * identifier);
@@ -100,7 +100,7 @@ frida_system_enumerate_applications (FridaApplicationQueryOptions * options, int
   return NULL;
 }
 
-#elif defined (HAVE_IOS) || defined (HAVE_TVOS)
+#elif defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
 
 void
 frida_system_get_frontmost_application (FridaFrontmostQueryOptions * options, FridaHostApplicationInfo * result, GError ** error)
@@ -306,7 +306,7 @@ frida_system_enumerate_processes (FridaProcessQueryOptions * options, int * resu
   NSAutoreleasePool * pool;
 
   op.scope = frida_process_query_options_get_scope (options);
-#if defined (HAVE_IOS) || defined (HAVE_TVOS)
+#if defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
   op.api = _frida_get_springboard_api ();
 #endif
 
@@ -395,7 +395,7 @@ frida_collect_process_info_from_kinfo (struct kinfo_proc * process, FridaEnumera
         frida_add_app_icons (info.parameters, app.icon);
     }
   }
-#elif defined (HAVE_IOS) || defined (HAVE_TVOS)
+#elif defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
   {
     FridaSpringboardApi * api = op->api;
     NSString * identifier;
@@ -469,7 +469,7 @@ frida_temporary_directory_get_system_tmp (void)
   }
 }
 
-#if defined (HAVE_MACOS) || defined (HAVE_IOS) || defined (HAVE_TVOS)
+#if defined (HAVE_MACOS) || defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
 
 static void
 frida_add_app_id (GHashTable * parameters, NSString * identifier)
@@ -541,7 +541,7 @@ frida_add_app_icons (GHashTable * parameters, NSImage * image)
   g_hash_table_insert (parameters, g_strdup ("icons"), g_variant_ref_sink (g_variant_builder_end (&builder)));
 }
 
-#elif defined (HAVE_IOS) || defined (HAVE_TVOS)
+#elif defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
 
 static void
 frida_add_app_metadata (GHashTable * parameters, NSString * identifier, FridaSpringboardApi * api)

--- a/src/embed-agent.py
+++ b/src/embed-agent.py
@@ -58,7 +58,7 @@ def main(argv):
             for asset in {embedded_agent, embedded_dbghelp, embedded_symsrv}:
                 asset.write_bytes(b"")
                 embedded_assets += [asset]
-    elif host_os in {"macos", "ios", "watchos", "tvos"}:
+    elif host_os in {"macos", "ios", "watchos", "tvos", "xros"}:
         embedded_agent = priv_dir / "frida-agent.dylib"
         if agent_modern is not None and agent_legacy is not None:
             subprocess.run(lipo + [agent_modern, agent_legacy, "-create", "-output", embedded_agent],

--- a/src/embed-helper.py
+++ b/src/embed-helper.py
@@ -36,7 +36,7 @@ def main(argv):
             embedded_helper = priv_dir / f"frida-helper-{missing_arch}.exe"
             embedded_helper.write_bytes(b"")
             embedded_assets += [embedded_helper]
-    elif host_os in {"macos", "ios", "watchos", "tvos"}:
+    elif host_os in {"macos", "ios", "watchos", "tvos", "xros"}:
         embedded_helper = priv_dir / "frida-helper"
 
         if helper_modern is not None and helper_legacy is not None:

--- a/src/meson.build
+++ b/src/meson.build
@@ -167,7 +167,7 @@ if have_local_backend
       'darwin' / 'policy-softener.vala',
       'darwin' / 'policy-softener-glue.c',
     ]
-    if host_os in ['macos', 'ios', 'tvos']
+    if host_os in ['macos', 'ios', 'tvos', 'xros']
       helper_backend_sources += [
         'darwin' / 'frida-helper-backend.vala',
         'darwin' / 'frida-helper-backend-glue.m',
@@ -179,7 +179,7 @@ if have_local_backend
         'darwin' / 'frida-helper-null-backend.vala',
       ]
     endif
-    if host_os in ['ios', 'tvos']
+    if host_os in ['ios', 'tvos', 'xros']
       helper_backend_sources += [
         'darwin' / 'springboard.m',
         'darwin' / 'substituted-client.c',

--- a/tests/process-resource-usage.c
+++ b/tests/process-resource-usage.c
@@ -5,7 +5,7 @@
 # include <psapi.h>
 typedef HANDLE FridaProcessHandle;
 #elif defined (HAVE_DARWIN)
-# if defined (HAVE_IOS) || defined (HAVE_TVOS)
+# if defined (HAVE_IOS) || defined (HAVE_TVOS) || defined (HAVE_XROS)
 #  define PROC_PIDLISTFDS 1
 #  define PROC_PIDLISTFD_SIZE (sizeof (struct proc_fdinfo))
 struct proc_fdinfo


### PR DESCRIPTION
I’m attempting to compile frida-gadget for visionOS 26. So far, I’ve modified the releng, frida-core, and frida-gum projects and submitted pull requests for them.

Since I’m not very familiar with Vala and Meson, I took a rather straightforward approach by simply adding XROS wherever the IOS macro was used. I also made minor changes to libffi (although I believe a better solution would be to upgrade it).

At the moment, the build completes successfully, and an Xcode visionOS app can also compile without issues. However, the app crashes at runtime. Below is the call stack.

I’m not very familiar with Frida’s internal mechanisms, so I may need some help.

```
dyld`__abort_with_payload:
    0x19af9d010 <+0>:  mov    x16, #0x209               ; =521 
    0x19af9d014 <+4>:  svc    #0x80
->  0x19af9d018 <+8>:  b.lo   0x19af9d038               ; <+40>
    0x19af9d01c <+12>: pacibsp 
    0x19af9d020 <+16>: stp    x29, x30, [sp, #-0x10]!
    0x19af9d024 <+20>: mov    x29, sp
    0x19af9d028 <+24>: bl     0x19b01ab74               ; cerror_nocancel
    0x19af9d02c <+28>: mov    sp, x29
    0x19af9d030 <+32>: ldp    x29, x30, [sp], #0x10
    0x19af9d034 <+36>: retab  
    0x19af9d038 <+40>: ret    



dyld`abort_with_payload_wrapper_internal:
    0x19b01e818 <+0>:   pacibsp 
    0x19b01e81c <+4>:   sub    sp, sp, #0x50
    0x19b01e820 <+8>:   stp    x24, x23, [sp, #0x10]
    0x19b01e824 <+12>:  stp    x22, x21, [sp, #0x20]
    0x19b01e828 <+16>:  stp    x20, x19, [sp, #0x30]
    0x19b01e82c <+20>:  stp    x29, x30, [sp, #0x40]
    0x19b01e830 <+24>:  add    x29, sp, #0x40
    0x19b01e834 <+28>:  mov    x19, x5
    0x19b01e838 <+32>:  mov    x20, x4
    0x19b01e83c <+36>:  mov    x21, x3
    0x19b01e840 <+40>:  mov    x22, x2
    0x19b01e844 <+44>:  mov    x23, x1
    0x19b01e848 <+48>:  mov    x24, x0
    0x19b01e84c <+52>:  mov    w8, #0x20                 ; =32 
    0x19b01e850 <+56>:  str    w8, [sp, #0xc]
    0x19b01e854 <+60>:  add    x1, sp, #0xc
    0x19b01e858 <+64>:  mov    w0, #0x2                  ; =2 
    0x19b01e85c <+68>:  mov    x2, #0x0                  ; =0 
    0x19b01e860 <+72>:  bl     0x19af9df00               ; sigprocmask
    0x19b01e864 <+76>:  mov    x0, x24
    0x19b01e868 <+80>:  mov    x1, x23
    0x19b01e86c <+84>:  mov    x2, x22
    0x19b01e870 <+88>:  mov    x3, x21
    0x19b01e874 <+92>:  mov    x4, x20
    0x19b01e878 <+96>:  mov    x5, x19
    0x19b01e87c <+100>: bl     0x19af9d010               ; __abort_with_payload
->  0x19b01e880 <+104>: bl     0x19af9d278               ; __getpid
    0x19b01e884 <+108>: orr    x6, x19, #0x200
    0x19b01e888 <+112>: mov    x1, x24
    0x19b01e88c <+116>: mov    x2, x23
    0x19b01e890 <+120>: mov    x3, x22
    0x19b01e894 <+124>: mov    x4, x21
    0x19b01e898 <+128>: mov    x5, x20
    0x19b01e89c <+132>: bl     0x19b01ae28               ; terminate_with_payload
    0x19b01e8a0 <+136>: brk    #0x1


dyld`abort_with_payload:
    0x19b01e8a4 <+0>:  pacibsp 
    0x19b01e8a8 <+4>:  stp    x29, x30, [sp, #-0x10]!
    0x19b01e8ac <+8>:  mov    x29, sp
    0x19b01e8b0 <+12>: bl     0x19b01e818               ; abort_with_payload_wrapper_internal


dyld`dyld4::halt:
    0x19afa4710 <+0>:   pacibsp 
    0x19afa4714 <+4>:   stp    x28, x27, [sp, #-0x40]!
    0x19afa4718 <+8>:   stp    x22, x21, [sp, #0x10]
    0x19afa471c <+12>:  stp    x20, x19, [sp, #0x20]
    0x19afa4720 <+16>:  stp    x29, x30, [sp, #0x30]
    0x19afa4724 <+20>:  add    x29, sp, #0x30
    0x19afa4728 <+24>:  sub    sp, sp, #0xc10
    0x19afa472c <+28>:  mov    x21, x1
    0x19afa4730 <+32>:  mov    x19, x0
    0x19afa4734 <+36>:  add    x22, sp, #0x410
    0x19afa4738 <+40>:  adrp   x20, 452983
    0x19afa473c <+44>:  add    x20, x20, #0xff0          ; dyld4::error_string
    0x19afa4740 <+48>:  mov    x0, x20
    0x19afa4744 <+52>:  mov    x1, x19
    0x19afa4748 <+56>:  mov    w2, #0x400                ; =1024 
    0x19afa474c <+60>:  bl     0x19b00bde8               ; strlcpy
    0x19afa4750 <+64>:  adrp   x8, 452983
    0x19afa4754 <+68>:  str    x20, [x8, #0x5b0]
    0x19afa4758 <+72>:  str    x19, [sp]
    0x19afa475c <+76>:  adrp   x0, 124

dyld`dyld4::prepare:
    0x19afa1958 <+3732>: mov    x0, x20
    0x19afa195c <+3736>: bl     0x19afae950               ; dyld4::RuntimeState::notifyDebuggerLoad(std::__1::span<dyld4::Loader const*, 18446744073709551615ul> const&)
    0x19afa1960 <+3740>: ldr    x0, [x20, #0x268]
    0x19afa1964 <+3744>: mov    w1, #0x20                 ; =32 
    0x19afa1968 <+3748>: bl     0x19afea390               ; dyld4::ExternallyViewableState::setDyldState(unsigned char)
    0x19afa196c <+3752>: ldr    x0, [x20, #0x268]
    0x19afa1970 <+3756>: bl     0x19afec8ac               ; dyld4::ExternallyViewableState::disableCrashReportBacktrace()
    0x19afa1974 <+3760>: add    x0, x19, #0x130
    0x19afa1978 <+3764>: bl     0x19afffcc0               ; Diagnostics::errorMessage() const
    0x19afa197c <+3768>: add    x1, x20, #0x290
    0x19afa1980 <+3772>: bl     0x19afa4710               ; dyld4::halt(char const*, dyld4::StructuredError const*)
->  0x19afa1984 <+3776>: ldr    x0, [x20, #0x68]
    0x19afa1988 <+3780>: mov    x1, x20
    0x19afa198c <+3784>: bl     0x19afb8a4c               ; dyld4::Loader::path(dyld4::RuntimeState const&) const
    0x19afa1990 <+3788>: ldr    x8, [x20, #0x8]
    0x19afa1994 <+3792>: ldr    x8, [x8, #0x80]
    0x19afa1998 <+3796>: stp    x0, x8, [sp, #-0x10]!
    0x19afa199c <+3800>: adrp   x1, 127
    0x19afa19a0 <+3804>: add    x1, x1, #0xe4c            ; "'%s' not compatible with '%s'"
    0x19afa19a4 <+3808>: add    x0, x19, #0x20
    0x19afa19a8 <+3812>: bl     0x19b00f07c               ; mach_o::Error::Error(char const*, ...)

dyld`start:
    0x19afa0298 <+6212>: bl     0x19afcf3a0               ; lsl::MemoryManager::memoryManager()
    0x19afa029c <+6216>: ldr    x8, [sp, #0x1d0]
    0x19afa02a0 <+6220>: add    x1, x8, #0x468
    0x19afa02a4 <+6224>: bl     0x19afcf550               ; lsl::MemoryManager::setProtectedStack(lsl::ProtectedStack&)
    0x19afa02a8 <+6228>: ldr    x0, [sp, #0x50]
    0x19afa02ac <+6232>: ldr    x1, [sp, #0x1d0]
    0x19afa02b0 <+6236>: str    x0, [x1, #0x268]
    0x19afa02b4 <+6240>: bl     0x19afec9a4               ; dyld4::ExternallyViewableState::setRuntimeState(dyld4::RuntimeState*)
    0x19afa02b8 <+6244>: ldr    x0, [sp, #0x1d0]
    0x19afa02bc <+6248>: ldr    x1, [sp, #0x18]
    0x19afa02c0 <+6252>: bl     0x19afa0ac4               ; dyld4::prepare(dyld4::APIs&, mach_o::Header const*)
->  0x19afa02c4 <+6256>: str    x0, [sp, #0x38]
    0x19afa02c8 <+6260>: add    x8, sp, #0x1f0
    0x19afa02cc <+6264>: mov    x0, x20
    0x19afa02d0 <+6268>: bl     0x19afcf6b0               ; lsl::MemoryManager::lockGuard()
    0x19afa02d4 <+6272>: ldr    x8, [x20, #0x18]
    0x19afa02d8 <+6276>: subs   x8, x8, #0x1
    0x19afa02dc <+6280>: str    x8, [x20, #0x18]
    0x19afa02e0 <+6284>: b.ne   0x19afa02f0               ; <+6300>
    0x19afa02e4 <+6288>: mov    x0, x20
    0x19afa02e8 <+6292>: mov    w1, #0x1                  ; =1 
```