### PR TITLE
fix: #1192, fallback to usbmux connection when tunnel tcp connection gives timeout in open_tcp_channel()

### DIFF
--- a/src/fruity/device-monitor.vala
+++ b/src/fruity/device-monitor.vala
@@ -340,7 +340,7 @@ namespace Frida.Fruity {
 					var stream = yield tunnel.open_tcp_connection (port, cancellable);
 					return new TcpChannel () { stream = stream, kind = TUNNEL };
 				} catch (Error e) {
-					if (e is Error.SERVER_NOT_RUNNING)
+					if (e is Error.SERVER_NOT_RUNNING || e is Error.TRANSPORT)
 						pending_error = e;
 					else
 						throw e;


### PR DESCRIPTION
Currently, if an initial tunnel connection attempt fails, Frida only falls back to other methods, such as usbmux, in the event of an `Error.SERVER_NOT_RUNNING`. If the failure is due to a network timeout or another transport-level issue, it is treated as a fatal error, which causes the process to hang. 
Therefore, adding the condition `|| e is Error.TRANSPORT` resolves this by classifying transport failures as non-fatal, which properly triggers a fallback to other methods like usbmux.