### PR TITLE
fruity: Throw CLOSED on tcp write in closed state

### DIFF
--- a/src/fruity/network-stack.vala
+++ b/src/fruity/network-stack.vala
@@ -760,8 +760,11 @@ namespace Frida.Fruity {
 					return OK;
 				}));
 
-				if (n == 0)
+				if (n == 0) {
+					if (state == CLOSED)
+						throw new IOError.CLOSED ("Connection is closed");
 					throw new IOError.WOULD_BLOCK ("Resource temporarily unavailable");
+				}
 
 				return n;
 			}


### PR DESCRIPTION
In this way the stream stops being polled and an infinite loop is avoided.