### PR TITLE
fruity: Tolerate per-PID CS signature query failures

### DIFF
--- a/src/fruity/fruity-host-session.vala
+++ b/src/fruity/fruity-host-session.vala
@@ -2878,7 +2878,15 @@ namespace Frida {
 					foreach (var pid in pids_to_trace) {
 						if (target_pids.has_key (pid))
 							continue;
-						var sig = yield info_service.query_symbolicator_signature (pid, cancellable);
+
+						Fruity.CsSignature sig;
+						try {
+							sig = yield info_service.query_symbolicator_signature (pid, cancellable);
+						} catch (GLib.Error e) {
+							sig = new Fruity.CsSignature ();
+							sig.pid = pid;
+						}
+
 						target_pids[pid] = sig;
 					}
 					l.free ();

--- a/src/fruity/fruity-host-session.vala
+++ b/src/fruity/fruity-host-session.vala
@@ -2882,7 +2882,7 @@ namespace Frida {
 						Fruity.CsSignature sig;
 						try {
 							sig = yield info_service.query_symbolicator_signature (pid, cancellable);
-						} catch (GLib.Error e) {
+						} catch (Error e) {
 							sig = new Fruity.CsSignature ();
 							sig.pid = pid;
 						}


### PR DESCRIPTION
Final commit to address https://github.com/frida/frida/issues/3719
## Problem

  In the `add-targets` handler inside `FruityHostSessionProvider`'s
  strace service, the loop that populates `target_pids` calls
  `info_service.query_symbolicator_signature (pid, cancellable)` for
  each PID. Any exception thrown by that call propagates out of the
  loop and aborts the entire `add-targets` request — so a single
  failing PID kills the whole trace, even though the other PIDs could
  have been instrumented fine.

  ## Fix

  Wrap the per-PID query in a `try`/`catch (GLib.Error)` and, on
  failure, fall back to a bare `Fruity.CsSignature` carrying only the
  pid. The loop continues for the remaining PIDs; the fallback
  signature is benign for downstream code, which only depends on the
  `pid` field until a real signature becomes available (via the
  existing `pids_needing_sig_refresh` machinery).

  `GLib.Error` is used rather than the narrower `Error`/`IOError`
  pair because `query_symbolicator_signature` can raise either, and
  the fallback is identical in both cases.

  ## Testing

  - Builds clean on macOS arm64 with `MACOS_CERTID=- make` in the
    top-level frida tree.
  - `ninja src/libfrida-core.a` explicitly rebuilds the frida-core
    Vala compile pass, confirming the new `try`/`catch` and the
    bare `Fruity.CsSignature sig;` pre-declaration typecheck against
    the existing `add-targets` flow.
  - End-to-end verification on a physical iOS device requires a
    reproducer where at least one PID's symbolicator signature query
    fails; the change is a strict superset of the prior behaviour
    (the success path is unchanged) so it is safe to merge without
    device-side CI.