### PR TITLE
(feat) Add support for (re)including syscalls with SyscallTracer

### DIFF
--- a/src/fruity/fruity-host-session.vala
+++ b/src/fruity/fruity-host-session.vala
@@ -2931,6 +2931,18 @@ namespace Frida {
 				return reply.end ();
 			}
 
+			if (type == "include-syscalls") {
+				reader.read_member ("native");
+				var nrs = read_int32_array (reader);
+				reader.end_member ();
+
+				var l = new MutexLocker (mutex);
+				excluded_syscalls.remove_all_array (nrs);
+				l.free ();
+
+				return reply.end ();
+			}
+
 			throw new Error.INVALID_ARGUMENT ("Unsupported request type: %s", type);
 		}
 

--- a/src/linux/linux-host-session.vala
+++ b/src/linux/linux-host-session.vala
@@ -2926,6 +2926,22 @@ namespace Frida {
 				return reply.end ();
 			}
 
+			if (type == "include-syscalls") {
+				if (reader.has_member ("native")) {
+					reader.read_member ("native");
+					foreach_uint32 (reader, nr => tracer.include_syscall (NATIVE, nr));
+					reader.end_member ();
+				}
+
+				if (reader.has_member ("compat32")) {
+					reader.read_member ("compat32");
+					foreach_uint32 (reader, nr => tracer.include_syscall (COMPAT32, nr));
+					reader.end_member ();
+				}
+
+				return reply.end ();
+			}
+
 			throw new Error.INVALID_ARGUMENT ("Unsupported request type: %s", type);
 		}
 

--- a/src/linux/syscall-tracer.vala
+++ b/src/linux/syscall-tracer.vala
@@ -124,6 +124,11 @@ public sealed class Frida.SyscallTracer : Object {
 		excluded_syscalls.update_u64_u8 (key, 1);
 	}
 
+	public void include_syscall (Abi abi, uint nr) throws Error {
+		uint64 key = ((uint64) abi << 32) | (uint64) nr;
+		excluded_syscalls.remove_u64 (key);
+	}
+
 	public DrainStatus drain_events (SyscallEventHandler on_event) {
 		var status = syscall_events_reader.drain (payload => {
 			assert (payload.length >= sizeof (SyscallEvent));


### PR DESCRIPTION
#1227 add `include-syscall` functionality to the `syscall-trace` service.
Have tested against android, but not yet iOS.
Ended up being a smaller change than I expected.