### PR TITLE
Fix empty FRIDA_ALLOWED_PREBUILDS producing invalid prebuild set

### DIFF
--- a/compat/build.py
+++ b/compat/build.py
@@ -373,7 +373,10 @@ def setup(role: Role,
         outputs = OrderedDict((g, items) for g, items in outputs.items() if items)
 
         raw_allowed_prebuilds = os.environ.get("FRIDA_ALLOWED_PREBUILDS")
-        allowed_prebuilds = set(raw_allowed_prebuilds.split(",")) if raw_allowed_prebuilds is not None else None
+        if raw_allowed_prebuilds is not None:
+            allowed_prebuilds = set(filter(None, raw_allowed_prebuilds.split(",")))
+        else:
+            allowed_prebuilds = None
 
         state = State(role, builddir, top_builddir, frida_version, host_os, host_config, glib_flavor, allowed_prebuilds, outputs)
         serialized_state = base64.b64encode(pickle.dumps(state)).decode('ascii')


### PR DESCRIPTION
## Summary

When `FRIDA_ALLOWED_PREBUILDS` is set to an empty string (e.g. when building with `--without-prebuilds` on platforms without prebuilt binaries), `"".split(",")` produces `['']` instead of `[]`.

This results in a set containing an empty string `{''}` rather than an empty set `set()`, which is then passed as `allowed` to the build system causing it to attempt downloading nonexistent prebuilds and fail.

## Fix

Use `filter(None, ...)` to strip empty strings from the split result, so an empty env var correctly produces an empty set.

## Context

This was found while building Frida from source on FreeBSD 15.0, where no prebuilt toolchain/SDK binaries are available. The build with `FRIDA_ALLOWED_PREBUILDS="" ./configure --without-prebuilds=toolchain,sdk` was failing because the empty string in the set was not being handled correctly.

The bug is platform-independent — it affects any build where `FRIDA_ALLOWED_PREBUILDS` is explicitly set to an empty value.