### PR TITLE
native termux support

### DIFF
--- a/compat/build.py
+++ b/compat/build.py
@@ -350,7 +350,7 @@ def setup(role: Role,
                                target=AGENT_TARGET),
                     ]
 
-        if glib_flavor == "upstream":
+        if glib_flavor == "upstream" and len(compat) > 0:
             kind = "modern" if arch_is_modern(host_os, host_arch) else "legacy"
             _, agent_file, gadget_file = native_file_paths(host_os)
             group = OutputGroup(host_arch)
@@ -496,7 +496,10 @@ def compile(privdir: Path, state: State):
             host_machine = MachineSpec(state.host_os, group.arch, state.host_config, group.triplet)
 
             if state.glib_flavor == "upstream":
-                allowed = None
+                if state.allowed_prebuilds is not None and len(state.allowed_prebuilds) == 0:
+                    allowed = state.allowed_prebuilds
+                else:
+                    allowed = None
             else:
                 allowed = state.allowed_prebuilds
 

--- a/lib/payload/libc-shim.c
+++ b/lib/payload/libc-shim.c
@@ -59,6 +59,9 @@
 #ifdef HAVE_MUSL
 # define FRIDA_STDIO_OPAQUE_FILE 1
 #endif
+#ifdef HAVE_ANDROID
+# define FRIDA_STDIO_OPAQUE_FILE 1
+#endif
 
 static gboolean frida_deinit_expected = FALSE;
 
@@ -254,9 +257,11 @@ static off_t frida_lseek_nointr (int fd, off_t offset, int whence);
 #ifndef FRIDA_STDIO_OPAQUE_FILE
 G_GNUC_INTERNAL FILE __sF[3];
 
+# ifndef __ANDROID__
 G_GNUC_INTERNAL FILE * stdin = &__sF[0];
 G_GNUC_INTERNAL FILE * stdout = &__sF[1];
 G_GNUC_INTERNAL FILE * stderr = &__sF[2];
+# endif
 
 # ifdef HAVE_DARWIN
 G_GNUC_INTERNAL FILE * __stdinp = &__sF[0];
@@ -266,9 +271,11 @@ G_GNUC_INTERNAL FILE * __stderrp = &__sF[2];
 #else
 static FridaFileHandle frida_stdio[3];
 
+# ifndef __ANDROID__
 G_GNUC_INTERNAL FILE * const stdin = (FILE *) &frida_stdio[0];
 G_GNUC_INTERNAL FILE * const stdout = (FILE *) &frida_stdio[1];
 G_GNUC_INTERNAL FILE * const stderr = (FILE *) &frida_stdio[2];
+# endif
 #endif
 
 static gboolean frida_libc_shim_initialized = FALSE;
@@ -1512,6 +1519,7 @@ getline (char ** lineptr, size_t * n, FILE * stream)
   return getdelim (lineptr, n, '\n', stream);
 }
 
+#ifndef FRIDA_STDIO_OPAQUE_FILE
 G_GNUC_INTERNAL FILE *
 tmpfile (void)
 {
@@ -1535,6 +1543,8 @@ tmpfile (void)
 
   return result;
 }
+
+#endif
 
 G_GNUC_INTERNAL int
 putchar (int c)

--- a/vapi/minizip.vapi
+++ b/vapi/minizip.vapi
@@ -4,7 +4,7 @@ namespace Minizip {
 	[CCode (cheader_filename = "minizip/mz_strm.h,minizip/mz_zip.h,minizip/mz_zip_rw.h", cname = "gpointer", cprefix = "mz_zip_reader_",
 		has_destroy_function = false)]
 	public struct Reader {
-		public static Reader create (out Reader stream = null);
+		public static Reader create ();
 		[CCode (cname = "mz_zip_reader_delete")]
 		public static void destroy (ref Reader stream);
 

--- a/vapi/minizip.vapi
+++ b/vapi/minizip.vapi
@@ -4,7 +4,7 @@ namespace Minizip {
 	[CCode (cheader_filename = "minizip/mz_strm.h,minizip/mz_zip.h,minizip/mz_zip_rw.h", cname = "gpointer", cprefix = "mz_zip_reader_",
 		has_destroy_function = false)]
 	public struct Reader {
-		public static Reader create ();
+		public static Reader create (out Reader stream = null);
 		[CCode (cname = "mz_zip_reader_delete")]
 		public static void destroy (ref Reader stream);
 


### PR DESCRIPTION
Changes descriptions:
- The `glib_flavor == "upstream"` path unconditionally creates an arm64 output group that triggers a separate meson configure for building agent/gadget binaries, which tries to download the prebuilt toolchain from `build.frida.re`. Even with `compat=disabled`, this code path runs.
- When `state.allowed_prebuilds` is an empty set (from `--without-prebuilds`), the code overrides `allowed` to `None`, re-enabling all prebuild downloads.
- Android Bionic has opaque `FILE*` struct (like musl), but the code only guards with `#ifdef HAVE_MUSL`. Accessing `FILE->_lbf_size` etc. fails on Bionic.
- Bionic's `<stdio.h>` already defines `stdin`, `stdout`, `stderr` `tmpfile()` as macros/inline functions. Frida's shim redefines them, causing compile errors.