### PR TITLE
android: fix package name when spawned activity has android:process

### DIFF
--- a/src/linux/helpers/zymbiote.c
+++ b/src/linux/helpers/zymbiote.c
@@ -16,7 +16,7 @@ struct _ZymbioteContext
   size_t payload_size;
   size_t payload_original_protection;
 
-  char * package_name;
+  char * process_name;
 
   int     (* original_setcontext) (uid_t uid, bool is_system_server, const char * seinfo, const char * name);
   void    (* original_set_argv0) (JNIEnv * env, jobject clazz, jstring name);
@@ -43,7 +43,7 @@ ZymbioteContext zymbiote =
 int frida_zymbiote_replacement_setargv0 (JNIEnv * env, jobject clazz, jstring name);
 int frida_zymbiote_replacement_setcontext (uid_t uid, bool is_system_server, const char * seinfo, const char * name);
 
-static void frida_wait_for_permission_to_resume (const char * package_name, bool * revert_now);
+static void frida_wait_for_permission_to_resume (const char * process_name, bool * revert_now);
 
 static int frida_stop_and_return_from_setargv0 (JNIEnv * env, jobject clazz, jstring name);
 
@@ -65,10 +65,10 @@ frida_zymbiote_replacement_setcontext (uid_t uid, bool is_system_server, const c
   if (res == -1)
     return -1;
 
-  if (zymbiote.package_name == NULL)
+  if (zymbiote.process_name == NULL)
   {
     zymbiote.mprotect (zymbiote.payload_base, zymbiote.payload_size, PROT_READ | PROT_WRITE | PROT_EXEC);
-    zymbiote.package_name = zymbiote.strdup (name);
+    zymbiote.process_name = zymbiote.strdup (name);
   }
 
   return res;
@@ -84,17 +84,17 @@ frida_zymbiote_replacement_setargv0 (JNIEnv * env, jobject clazz, jstring name)
 
   zymbiote.original_set_argv0 (env, clazz, name);
 
-  if (zymbiote.package_name != NULL)
-    name_utf8 = zymbiote.package_name;
+  if (zymbiote.process_name != NULL)
+    name_utf8 = zymbiote.process_name;
   else
     name_utf8 = (*env)->GetStringUTFChars (env, name, NULL);
 
   frida_wait_for_permission_to_resume (name_utf8, &revert_now);
 
-  if (zymbiote.package_name != NULL)
+  if (zymbiote.process_name != NULL)
   {
-    zymbiote.free (zymbiote.package_name);
-    zymbiote.package_name = NULL;
+    zymbiote.free (zymbiote.process_name);
+    zymbiote.process_name = NULL;
     zymbiote.mprotect (zymbiote.payload_base, zymbiote.payload_size, zymbiote.payload_original_protection);
   }
   else
@@ -112,7 +112,7 @@ frida_zymbiote_replacement_setargv0 (JNIEnv * env, jobject clazz, jstring name)
 }
 
 static void
-frida_wait_for_permission_to_resume (const char * package_name, bool * revert_now)
+frida_wait_for_permission_to_resume (const char * process_name, bool * revert_now)
 {
   int fd;
   struct sockaddr_un addr;
@@ -151,22 +151,22 @@ frida_wait_for_permission_to_resume (const char * package_name, bool * revert_no
     {
       uint32_t pid;
       uint32_t ppid;
-      uint32_t package_name_len;
+      uint32_t process_name_len;
     } header;
     struct iovec iov[2];
 
     header.pid = zymbiote.getpid ();
     header.ppid = zymbiote.getppid ();
 
-    header.package_name_len = 0;
-    while (package_name[header.package_name_len] != '\0')
-      header.package_name_len++;
+    header.process_name_len = 0;
+    while (process_name[header.process_name_len] != '\0')
+      header.process_name_len++;
 
     iov[0].iov_base = &header;
     iov[0].iov_len = sizeof (header);
 
-    iov[1].iov_base = (void *) package_name;
-    iov[1].iov_len = header.package_name_len;
+    iov[1].iov_base = (void *) process_name;
+    iov[1].iov_len = header.process_name_len;
 
     if (!frida_sendmsg_all (fd, iov, 2, MSG_NOSIGNAL))
       goto beach;

--- a/src/linux/linux-host-session.vala
+++ b/src/linux/linux-host-session.vala
@@ -2053,7 +2053,7 @@ namespace Frida {
 			try {
 				var hello = yield connection.read_hello (io_cancellable);
 
-				if (hello.package_name == CHROME_ZYGOTE_PACKAGE_NAME) {
+				if (hello.process_name == CHROME_ZYGOTE_PACKAGE_NAME) {
 					var patches = zymbiote_patches[hello.ppid];
 					if (patches != null)
 						zymbiote_patches[hello.pid] = patches;
@@ -2068,12 +2068,17 @@ namespace Frida {
 
 				bool needs_resume = false;
 
+				string package_name = hello.process_name;
+				int colon = package_name.index_of_char (':');
+				if (colon != -1)
+					package_name = package_name[:colon];
+
 				Promise<uint> spawn_request;
-				if (spawn_requests.unset (hello.package_name, out spawn_request)) {
+				if (spawn_requests.unset (package_name, out spawn_request)) {
 					spawn_request.resolve (hello.pid);
 					needs_resume = true;
 				} else if (spawn_gating_enabled) {
-					var spawn_info = HostSpawnInfo (hello.pid, hello.package_name);
+					var spawn_info = HostSpawnInfo (hello.pid, hello.process_name);
 					pending_spawn[hello.pid] = spawn_info;
 					spawn_added (spawn_info);
 					needs_resume = true;
@@ -2139,10 +2144,10 @@ namespace Frida {
 				try {
 					yield prepare_to_read (header_size, cancellable);
 
-					uint32 package_name_len = 0;
-					input.peek ((uint8[]) &package_name_len, 8);
+					uint32 process_name_len = 0;
+					input.peek ((uint8[]) &process_name_len, 8);
 
-					size_t message_size = header_size + package_name_len;
+					size_t message_size = header_size + process_name_len;
 
 					yield prepare_to_read (message_size, cancellable);
 
@@ -2150,12 +2155,12 @@ namespace Frida {
 					uint32 pid = r.read_uint32 ();
 					uint32 ppid = r.read_uint32 ();
 					r.skip (4);
-					string package_name = r.read_fixed_string (package_name_len);
+					string process_name = r.read_fixed_string (process_name_len);
 
 					hello = new Hello () {
 						pid = pid,
 						ppid = ppid,
-						package_name = package_name,
+						process_name = process_name,
 					};
 
 					return hello;
@@ -2169,7 +2174,7 @@ namespace Frida {
 			public class Hello {
 				public uint pid;
 				public uint ppid;
-				public string package_name;
+				public string process_name;
 			}
 
 			public async void resume (Cancellable? cancellable) throws Error, IOError {


### PR DESCRIPTION
If an activity declares android:process, the process forked from zygote has a name like "com.example.app:foo" instead of "com.example.app". The zymbiote sends process name "com.example.app:foo" in its hello, but spawn_request holds the package name "com.example.app". Since the names don't match, it keeps waiting for the spawn to complete until timeout is reached.

We strip the colon suffix from the process name before matching, since the part after colon is not part of the package name. Also rename package_name to process_name to reflect what it actually contains.