### PR TITLE
Document the public API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ fromJSON(matrix.runner) }}
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Install MinGW toolchain for cgo support
@@ -42,7 +42,7 @@ jobs:
           msystem: ${{ matrix.sys }}
           install: ${{ matrix.pkg }}
       - name: Install Go toolchain
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'src/compiler/go.mod'
           cache-dependency-path: 'src/compiler/go.mod'
@@ -95,7 +95,7 @@ jobs:
           make
       - name: Upload devkit
         if: ${{ !startsWith(matrix.id, 'linux-') }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: core-devkit-${{ matrix.id }}
           path: build/src/devkit/
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Install toolchain
@@ -151,7 +151,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install ${{ matrix.pkg }}
       - name: Install Go toolchain
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'src/compiler/go.mod'
           cache-dependency-path: 'src/compiler/go.mod'
@@ -164,7 +164,7 @@ jobs:
           make
       - name: Upload devkit
         if: ${{ !startsWith(matrix.id, 'linux-') }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: core-devkit-${{ matrix.id }}
           path: build/src/devkit/
@@ -178,11 +178,11 @@ jobs:
     container: ghcr.io/frida/x-tools-linux-${{ matrix.arch }}:latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Install Go toolchain
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'src/compiler/go.mod'
           cache-dependency-path: 'src/compiler/go.mod'
@@ -194,7 +194,7 @@ jobs:
               ${{ env.FRIDA_CORE_OPTIONS }}
           make
       - name: Upload devkit
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: core-devkit-linux-${{ matrix.arch }}
           path: build/src/devkit/
@@ -211,7 +211,7 @@ jobs:
     container: ghcr.io/frida/x-tools-linux-${{ matrix.arch }}:latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Build
@@ -342,11 +342,11 @@ jobs:
     runs-on: ${{ startsWith(matrix.id, 'ios-') && 'macos-latest' || 'ubuntu-latest' }}
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Install Go toolchain
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'src/compiler/go.mod'
           cache-dependency-path: 'src/compiler/go.mod'
@@ -373,7 +373,7 @@ jobs:
               ${{ env.FRIDA_CORE_OPTIONS }}
           make
       - name: Upload devkit
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: core-devkit-${{ matrix.id }}
           path: build/src/devkit/
@@ -432,7 +432,7 @@ jobs:
     container: ghcr.io/frida/qnx-tools:latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Build
@@ -441,7 +441,7 @@ jobs:
               ./configure --host=arm-unknown-nto-qnx6.5.0eabi ${{ env.FRIDA_CORE_OPTIONS }}
           make
       - name: Upload devkit
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: core-devkit-qnx-armeabi
           path: build/src/devkit/
@@ -467,7 +467,7 @@ jobs:
     container: ghcr.io/frida/core-linux-helpers-${{ matrix.arch }}:latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Build
@@ -501,7 +501,7 @@ jobs:
     container: ghcr.io/frida/core-linux-helpers-${{ matrix.arch }}:latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Build
@@ -530,24 +530,24 @@ jobs:
       - mobile
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Download macOS/x86_64 devkit
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: core-devkit-macos-x86_64
           path: devkits/macos-x86_64
       - name: Download macOS/arm64 devkit
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: core-devkit-macos-arm64
           path: devkits/macos-arm64
       - name: Download iOS/arm64 devkit
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: core-devkit-ios-arm64
           path: devkits/ios-arm64
       - name: Download iOS/arm64-simulator devkit
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: core-devkit-ios-arm64-simulator
           path: devkits/ios-arm64-simulator
@@ -610,7 +610,7 @@ jobs:
               -headers xcframework_headers/ios-arm64-simulator \
               -output FridaCore.xcframework
       - name: Upload FridaCore.xcframework
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: FridaCore.xcframework
           path: FridaCore.xcframework
@@ -622,7 +622,7 @@ jobs:
       - xcframework
     steps:
       - name: Download FridaCore.xcframework artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: FridaCore.xcframework
           path: dist
@@ -645,7 +645,7 @@ jobs:
           cd dist
           zip -r FridaCore.xcframework.zip FridaCore.xcframework
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             dist/FridaCore.xcframework.zip

--- a/lib/base/rpc.vala
+++ b/lib/base/rpc.vala
@@ -1,5 +1,11 @@
 namespace Frida {
+	/**
+	 * Issues RPC calls over a {@link RpcPeer}, matching responses to requests.
+	 */
 	public sealed class RpcClient : Object {
+		/**
+		 * The peer used to send and receive RPC messages.
+		 */
 		public weak RpcPeer peer {
 			get;
 			construct;
@@ -7,10 +13,23 @@ namespace Frida {
 
 		private Gee.HashMap<string, PendingResponse> pending_responses = new Gee.HashMap<string, PendingResponse> ();
 
+		/**
+		 * Creates an RPC client that talks over @peer.
+		 *
+		 * @param peer the peer to send and receive messages through
+		 */
 		public RpcClient (RpcPeer peer) {
 			Object (peer: peer);
 		}
 
+		/**
+		 * Calls a remote method and waits for its result.
+		 *
+		 * @param method the method name to invoke
+		 * @param args the JSON arguments
+		 * @param data binary data to accompany the call, if any
+		 * @return the method's JSON result
+		 */
 		public async Json.Node call (string method, Json.Node[] args, Bytes? data, Cancellable? cancellable) throws Error, IOError {
 			string request_id = Uuid.string_random ();
 
@@ -157,7 +176,17 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * A transport over which an {@link RpcClient} sends and receives RPC
+	 * messages.
+	 */
 	public interface RpcPeer : Object {
+		/**
+		 * Posts an RPC message to the peer.
+		 *
+		 * @param json the message as a JSON string
+		 * @param data binary data to accompany the message, if any
+		 */
 		public abstract async void post_rpc_message (string json, Bytes? data, Cancellable? cancellable) throws Error, IOError;
 	}
 }

--- a/lib/base/rpc.vala
+++ b/lib/base/rpc.vala
@@ -88,6 +88,13 @@ namespace Frida {
 			return pending.result;
 		}
 
+		/**
+		 * Feeds an incoming message to the client, matching it against pending
+		 * calls if it is an RPC response.
+		 *
+		 * @param json the incoming message as a JSON string
+		 * @return true if the message was an RPC message and was handled
+		 */
 		public bool try_handle_message (string json) {
 			if (json.index_of ("\"frida:rpc\"") == -1)
 				return false;

--- a/lib/base/session.vala
+++ b/lib/base/session.vala
@@ -755,10 +755,25 @@ namespace Frida {
 		public abstract async void break_and_detach (Cancellable? cancellable) throws GLib.Error;
 	}
 
+	/**
+	 * What the Gadget should do when a configured breakpoint is hit.
+	 */
 	public enum GadgetBreakpointAction {
+		/**
+		 * Invoke the function and return immediately.
+		 */
 		INVOKE_RETURN,
+		/**
+		 * Resume execution.
+		 */
 		RESUME,
+		/**
+		 * Detach the Gadget.
+		 */
 		DETACH,
+		/**
+		 * Apply the page plan.
+		 */
 		PAGE_PLAN,
 	}
 
@@ -802,16 +817,37 @@ namespace Frida {
 	}
 
 	[DBus (name = "re.frida.AuthenticationService17")]
+	/**
+	 * Authenticates clients connecting to a {@link PortalService} or
+	 * {@link ControlService}.
+	 */
 	public interface AuthenticationService : Object {
+		/**
+		 * Authenticates a client by its token.
+		 *
+		 * @param token the token presented by the client
+		 * @return a JSON string describing the authenticated session
+		 */
 		public abstract async string authenticate (string token, Cancellable? cancellable) throws GLib.Error;
 	}
 
+	/**
+	 * An {@link AuthenticationService} that accepts a single fixed token.
+	 */
 	public sealed class StaticAuthenticationService : Object, AuthenticationService {
+		/**
+		 * The SHA-256 hash of the accepted token.
+		 */
 		public string token_hash {
 			get;
 			construct;
 		}
 
+		/**
+		 * Creates a service that accepts the given token.
+		 *
+		 * @param token the token clients must present
+		 */
 		public StaticAuthenticationService (string token) {
 			Object (token_hash: Checksum.compute_for_string (SHA256, token));
 		}
@@ -966,9 +1002,21 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * How the agent should take over exception handling in the target.
+	 */
 	public enum Exceptor {
+		/**
+		 * Install handlers and keep the target from overriding them.
+		 */
 		FULL,
+		/**
+		 * Install handlers but let the target replace them.
+		 */
 		HANDLER_ONLY,
+		/**
+		 * Do not handle exceptions.
+		 */
 		OFF;
 
 		public static Exceptor from_nick (string nick) throws Error {
@@ -2009,8 +2057,17 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * How a script's heap snapshot is delivered to the runtime.
+	 */
 	public enum SnapshotTransport {
+		/**
+		 * Embed the snapshot inline with the script.
+		 */
 		INLINE,
+		/**
+		 * Pass the snapshot through shared memory.
+		 */
 		SHARED_MEMORY
 	}
 
@@ -2110,17 +2167,29 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * Options for {@link Session.join_portal}.
+	 */
 	public sealed class PortalOptions : Object {
+		/**
+		 * TLS certificate to present to the portal.
+		 */
 		public TlsCertificate? certificate {
 			get;
 			set;
 		}
 
+		/**
+		 * Authentication token to present to the portal.
+		 */
 		public string? token {
 			get;
 			set;
 		}
 
+		/**
+		 * Access-control tags scoping what this membership may reach.
+		 */
 		public string[]? acl {
 			get;
 			set;
@@ -2173,7 +2242,14 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * Options for {@link Session.setup_peer_connection}, configuring how the
+	 * peer-to-peer connection is negotiated.
+	 */
 	public sealed class PeerOptions : Object {
+		/**
+		 * The STUN server to use for discovering the public address, if any.
+		 */
 		public string? stun_server {
 			get;
 			set;
@@ -2181,14 +2257,27 @@ namespace Frida {
 
 		private Gee.List<Relay> relays = new Gee.ArrayList<Relay> ();
 
+		/**
+		 * Removes all configured relays.
+		 */
 		public void clear_relays () {
 			relays.clear ();
 		}
 
+		/**
+		 * Adds a relay to use when a direct connection cannot be established.
+		 *
+		 * @param relay the relay to add
+		 */
 		public void add_relay (Relay relay) {
 			relays.add (relay);
 		}
 
+		/**
+		 * Invokes @func for each configured relay.
+		 *
+		 * @param func function called with each relay
+		 */
 		public void enumerate_relays (Func<Relay> func) {
 			foreach (var relay in relays)
 				func (relay);
@@ -2234,27 +2323,51 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * A TURN relay used to establish a peer-to-peer connection when a direct
+	 * one is not possible.
+	 */
 	public sealed class Relay : Object {
+		/**
+		 * The relay's address, as host and port.
+		 */
 		public string address {
 			get;
 			construct;
 		}
 
+		/**
+		 * The username to authenticate with.
+		 */
 		public string username {
 			get;
 			construct;
 		}
 
+		/**
+		 * The password to authenticate with.
+		 */
 		public string password {
 			get;
 			construct;
 		}
 
+		/**
+		 * The kind of relay and transport to use.
+		 */
 		public RelayKind kind {
 			get;
 			construct;
 		}
 
+		/**
+		 * Creates a relay.
+		 *
+		 * @param address the relay's address, as host and port
+		 * @param username the username to authenticate with
+		 * @param password the password to authenticate with
+		 * @param kind the kind of relay and transport
+		 */
 		public Relay (string address, string username, string password, RelayKind kind) {
 			Object (
 				address: address,
@@ -2281,9 +2394,21 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * The kind of a {@link Relay} used for peer-to-peer connections.
+	 */
 	public enum RelayKind {
+		/**
+		 * A TURN relay reached over UDP.
+		 */
 		TURN_UDP,
+		/**
+		 * A TURN relay reached over TCP.
+		 */
 		TURN_TCP,
+		/**
+		 * A TURN relay reached over TLS.
+		 */
 		TURN_TLS
 	}
 

--- a/lib/base/session.vala
+++ b/lib/base/session.vala
@@ -944,8 +944,17 @@ namespace Frida {
 		throw new Error.PERMISSION_DENIED ("Not authorized, authentication required");
 	}
 
+	/**
+	 * The realm an agent should run in.
+	 */
 	public enum Realm {
+		/**
+		 * The process's native realm.
+		 */
 		NATIVE,
+		/**
+		 * An emulated realm, such as code running under binary translation.
+		 */
 		EMULATED;
 
 		public static Realm from_nick (string nick) throws Error {
@@ -1045,11 +1054,29 @@ namespace Frida {
 	}
 #endif
 
+	/**
+	 * Why a {@link Session} was detached from its target.
+	 */
 	public enum SessionDetachReason {
+		/**
+		 * The host asked to detach.
+		 */
 		APPLICATION_REQUESTED = 1,
+		/**
+		 * The target process was replaced, for example by an exec.
+		 */
 		PROCESS_REPLACED,
+		/**
+		 * The target process exited.
+		 */
 		PROCESS_TERMINATED,
+		/**
+		 * The connection to the target was lost.
+		 */
 		CONNECTION_TERMINATED,
+		/**
+		 * The device became unreachable.
+		 */
 		DEVICE_LOST;
 
 		public static SessionDetachReason from_nick (string nick) throws Error {
@@ -1062,19 +1089,61 @@ namespace Frida {
 	}
 
 	[DBus (name = "re.frida.Error")]
+	/**
+	 * The errors that Frida operations can fail with.
+	 */
 	public errordomain Error {
+		/**
+		 * The frida-server is not running.
+		 */
 		SERVER_NOT_RUNNING,
+		/**
+		 * The specified executable was not found.
+		 */
 		EXECUTABLE_NOT_FOUND,
+		/**
+		 * The specified executable is not supported.
+		 */
 		EXECUTABLE_NOT_SUPPORTED,
+		/**
+		 * No process matched the request.
+		 */
 		PROCESS_NOT_FOUND,
+		/**
+		 * The process is not responding.
+		 */
 		PROCESS_NOT_RESPONDING,
+		/**
+		 * An argument was invalid.
+		 */
 		INVALID_ARGUMENT,
+		/**
+		 * The operation is not valid in the current state.
+		 */
 		INVALID_OPERATION,
+		/**
+		 * Permission was denied.
+		 */
 		PERMISSION_DENIED,
+		/**
+		 * The requested address is already in use.
+		 */
 		ADDRESS_IN_USE,
+		/**
+		 * The operation timed out.
+		 */
 		TIMED_OUT,
+		/**
+		 * The operation is not supported.
+		 */
 		NOT_SUPPORTED,
+		/**
+		 * A protocol error occurred.
+		 */
 		PROTOCOL,
+		/**
+		 * A transport-level error occurred.
+		 */
 		TRANSPORT
 	}
 
@@ -1141,7 +1210,13 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * Options for {@link Device.get_frontmost_application}.
+	 */
 	public sealed class FrontmostQueryOptions : Object {
+		/**
+		 * How much detail to include about the application.
+		 */
 		public Scope scope {
 			get;
 			set;
@@ -1171,7 +1246,14 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * Options for {@link Device.enumerate_applications}, including an optional
+	 * set of identifiers to restrict the results to.
+	 */
 	public sealed class ApplicationQueryOptions : Object {
+		/**
+		 * How much detail to include about each application.
+		 */
 		public Scope scope {
 			get;
 			set;
@@ -1180,14 +1262,30 @@ namespace Frida {
 
 		private Gee.List<string> identifiers = new Gee.ArrayList<string> ();
 
+		/**
+		 * Restricts the query to the given application identifier. May be called
+		 * multiple times to select several.
+		 *
+		 * @param identifier the application identifier to include
+		 */
 		public void select_identifier (string identifier) {
 			identifiers.add (identifier);
 		}
 
+		/**
+		 * Checks whether any identifiers have been selected.
+		 *
+		 * @return true if the query is restricted to specific identifiers
+		 */
 		public bool has_selected_identifiers () {
 			return !identifiers.is_empty;
 		}
 
+		/**
+		 * Invokes @func for each selected identifier.
+		 *
+		 * @param func function called with each identifier
+		 */
 		public void enumerate_selected_identifiers (Func<string> func) {
 			foreach (var identifier in identifiers)
 				func (identifier);
@@ -1229,7 +1327,14 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * Options for {@link Device.enumerate_processes}, including an optional set
+	 * of PIDs to restrict the results to.
+	 */
 	public sealed class ProcessQueryOptions : Object {
+		/**
+		 * How much detail to include about each process.
+		 */
 		public Scope scope {
 			get;
 			set;
@@ -1238,14 +1343,30 @@ namespace Frida {
 
 		private Gee.List<uint> pids = new Gee.ArrayList<uint> ();
 
+		/**
+		 * Restricts the query to the given PID. May be called multiple times to
+		 * select several.
+		 *
+		 * @param pid the process ID to include
+		 */
 		public void select_pid (uint pid) {
 			pids.add (pid);
 		}
 
+		/**
+		 * Checks whether any PIDs have been selected.
+		 *
+		 * @return true if the query is restricted to specific PIDs
+		 */
 		public bool has_selected_pids () {
 			return !pids.is_empty;
 		}
 
+		/**
+		 * Invokes @func for each selected PID.
+		 *
+		 * @param func function called with each PID
+		 */
 		public void enumerate_selected_pids (Func<uint> func) {
 			foreach (var pid in pids)
 				func (pid);
@@ -1287,9 +1408,21 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * How much detail to include in query results.
+	 */
 	public enum Scope {
+		/**
+		 * Only the essential fields.
+		 */
 		MINIMAL,
+		/**
+		 * Essential fields plus metadata.
+		 */
 		METADATA,
+		/**
+		 * Everything available.
+		 */
 		FULL;
 
 		public static Scope from_nick (string nick) throws Error {
@@ -1371,42 +1504,68 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * Options controlling how {@link Device.attach} sets up a {@link Session}.
+	 */
 	public sealed class SessionOptions : Object {
+		/**
+		 * The realm to attach in.
+		 */
 		public Realm realm {
 			get;
 			set;
 			default = NATIVE;
 		}
 
+		/**
+		 * How long the session may survive a disconnection before being torn
+		 * down, in seconds; 0 disables persistence.
+		 */
 		public uint persist_timeout {
 			get;
 			set;
 			default = 0;
 		}
 
+		/**
+		 * Path to a custom agent to use in the emulated realm.
+		 */
 		public string? emulated_agent_path {
 			get;
 			set;
 		}
 
+		/**
+		 * How the agent should handle exceptions in the target.
+		 */
 		public Exceptor exceptor {
 			get;
 			set;
 			default = FULL;
 		}
 
+		/**
+		 * Whether to install the unwind broker so exceptions can propagate
+		 * through instrumented code.
+		 */
 		public bool unwind_broker {
 			get;
 			set;
 			default = true;
 		}
 
+		/**
+		 * Whether to monitor the target for exit so the session is cleaned up.
+		 */
 		public bool exit_monitor {
 			get;
 			set;
 			default = true;
 		}
 
+		/**
+		 * Whether to monitor thread suspension in the target.
+		 */
 		public bool thread_suspend_monitor {
 			get;
 			set;
@@ -1415,14 +1574,28 @@ namespace Frida {
 
 		private Gee.List<uint> linker_notifier_offsets = new Gee.ArrayList<uint> ();
 
+		/**
+		 * Clears the configured linker notifier offsets.
+		 */
 		public void clear_linker_notifier_offsets () {
 			linker_notifier_offsets.clear ();
 		}
 
+		/**
+		 * Adds a linker notifier offset, used to detect module load and unload
+		 * events in the target.
+		 *
+		 * @param offset the offset into the linker to instrument
+		 */
 		public void add_linker_notifier_offset (uint offset) {
 			linker_notifier_offsets.add (offset);
 		}
 
+		/**
+		 * Invokes @func for each configured linker notifier offset.
+		 *
+		 * @param func function called with each offset
+		 */
 		public void enumerate_linker_notifier_offsets (Func<uint> func) {
 			foreach (var offset in linker_notifier_offsets)
 				func (offset);
@@ -1529,8 +1702,18 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * How to set up the standard I/O streams of a spawned process.
+	 */
 	public enum Stdio {
+		/**
+		 * Inherit the host's streams.
+		 */
 		INHERIT,
+		/**
+		 * Pipe the streams through Frida, surfaced via {@link Device.output}
+		 * and {@link Device.input}.
+		 */
 		PIPE;
 
 		public static Stdio from_nick (string nick) throws Error {
@@ -1594,9 +1777,21 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * How a {@link Child} came to be.
+	 */
 	public enum ChildOrigin {
+		/**
+		 * Created by fork().
+		 */
 		FORK,
+		/**
+		 * The result of an exec() replacing the image.
+		 */
 		EXEC,
+		/**
+		 * Spawned as a new process.
+		 */
 		SPAWN;
 
 		public static ChildOrigin from_nick (string nick) throws Error {
@@ -1713,23 +1908,39 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * Options for creating a {@link Script} with {@link Session.create_script}.
+	 */
 	public sealed class ScriptOptions : Object {
+		/**
+		 * A name for the script, used in logging and debugging.
+		 */
 		public string? name {
 			get;
 			set;
 		}
 
+		/**
+		 * A heap snapshot to start the script from, as produced by
+		 * {@link Session.snapshot_script}.
+		 */
 		public Bytes? snapshot {
 			get;
 			set;
 		}
 
+		/**
+		 * How the snapshot is delivered to the runtime.
+		 */
 		public SnapshotTransport snapshot_transport {
 			get;
 			set;
 			default = INLINE;
 		}
 
+		/**
+		 * Which JavaScript runtime to run the script in.
+		 */
 		public ScriptRuntime runtime {
 			get;
 			set;
@@ -1803,12 +2014,21 @@ namespace Frida {
 		SHARED_MEMORY
 	}
 
+	/**
+	 * Options for building a heap snapshot with {@link Session.snapshot_script}.
+	 */
 	public sealed class SnapshotOptions : Object {
+		/**
+		 * Script to run to warm up the runtime before capturing the snapshot.
+		 */
 		public string? warmup_script {
 			get;
 			set;
 		}
 
+		/**
+		 * Which JavaScript runtime to capture the snapshot for.
+		 */
 		public ScriptRuntime runtime {
 			get;
 			set;
@@ -1848,9 +2068,21 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * Which JavaScript runtime a script should use.
+	 */
 	public enum ScriptRuntime {
+		/**
+		 * Let Frida choose.
+		 */
 		DEFAULT,
+		/**
+		 * The QuickJS runtime.
+		 */
 		QJS,
+		/**
+		 * The V8 runtime.
+		 */
 		V8;
 
 		public static ScriptRuntime from_nick (string nick) throws Error {

--- a/lib/base/socket.vala
+++ b/lib/base/socket.vala
@@ -97,42 +97,77 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * Configures the network endpoint a {@link PortalService} or
+	 * {@link ControlService} listens on.
+	 */
 	public sealed class EndpointParameters : Object {
+		/**
+		 * The address to bind to, or null for the default.
+		 */
 		public string? address {
 			get;
 			construct;
 		}
 
+		/**
+		 * The port to listen on, or 0 for the default.
+		 */
 		public uint16 port {
 			get;
 			construct;
 		}
 
+		/**
+		 * TLS certificate to serve, enabling TLS when set.
+		 */
 		public TlsCertificate? certificate {
 			get;
 			construct;
 		}
 
+		/**
+		 * Origin to require from connecting clients, if any.
+		 */
 		public string? origin {
 			get;
 			construct;
 		}
 
+		/**
+		 * Service used to authenticate connecting clients, if any.
+		 */
 		public AuthenticationService? auth_service {
 			get;
 			construct;
 		}
 
+		/**
+		 * Directory whose files are served as static web assets, if any.
+		 */
 		public File? asset_root {
 			get;
 			set;
 		}
 
+		/**
+		 * Handler invoked for web requests, if any.
+		 */
 		public WebRequestHandler? request_handler {
 			get;
 			set;
 		}
 
+		/**
+		 * Creates endpoint parameters.
+		 *
+		 * @param address the address to bind to, or null for the default
+		 * @param port the port to listen on, or 0 for the default
+		 * @param certificate TLS certificate to serve, or null for plaintext
+		 * @param origin origin to require from clients, or null
+		 * @param auth_service service used to authenticate clients, or null
+		 * @param asset_root directory of static assets to serve, or null
+		 */
 		public EndpointParameters (string? address = null, uint16 port = 0, TlsCertificate? certificate = null,
 				string? origin = null, AuthenticationService? auth_service = null, File? asset_root = null) {
 			Object (
@@ -146,26 +181,51 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * Handles web requests made to an endpoint's served assets.
+	 */
 	public interface WebRequestHandler : Object {
+		/**
+		 * Handles a single web request.
+		 *
+		 * @param request the incoming request
+		 * @return the response to send, or null to fall through to the default
+		 *   handling
+		 */
 		public abstract async WebResponse? handle_request (WebRequest request, Cancellable? cancellable) throws Error, IOError;
 	}
 
+	/**
+	 * An incoming web request passed to a {@link WebRequestHandler}.
+	 */
 	public sealed class WebRequest : Object {
+		/**
+		 * The HTTP method, such as `GET` or `POST`.
+		 */
 		public string method {
 			get;
 			construct;
 		}
 
+		/**
+		 * The request path.
+		 */
 		public string path {
 			get;
 			construct;
 		}
 
+		/**
+		 * The raw query string, if any.
+		 */
 		public string? query_string {
 			get;
 			construct;
 		}
 
+		/**
+		 * The request body, if any.
+		 */
 		public Bytes? body {
 			get;
 			construct;
@@ -178,6 +238,11 @@ namespace Frida {
 			raw_headers = headers;
 		}
 
+		/**
+		 * Invokes @func for each request header.
+		 *
+		 * @param func function called with each header's name and value
+		 */
 		public void foreach_header (WebRequestHeaderFunc func) {
 			raw_headers.foreach ((name, val) => {
 				func (name, val);
@@ -185,14 +250,29 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * Callback invoked for each header while iterating a {@link WebRequest}.
+	 *
+	 * @param name the header name
+	 * @param val the header value
+	 */
 	public delegate void WebRequestHeaderFunc (string name, string val);
 
+	/**
+	 * A response returned from a {@link WebRequestHandler}.
+	 */
 	public sealed class WebResponse : Object {
+		/**
+		 * The HTTP status code.
+		 */
 		public uint status {
 			get;
 			construct;
 		}
 
+		/**
+		 * The response body.
+		 */
 		public Bytes body {
 			get;
 			construct;
@@ -200,10 +280,22 @@ namespace Frida {
 
 		private Soup.MessageHeaders raw_headers = new Soup.MessageHeaders (RESPONSE);
 
+		/**
+		 * Creates a response.
+		 *
+		 * @param status the HTTP status code
+		 * @param body the response body
+		 */
 		public WebResponse (uint status, Bytes body) {
 			Object (status: status, body: body);
 		}
 
+		/**
+		 * Adds a header to the response.
+		 *
+		 * @param name the header name
+		 * @param val the header value
+		 */
 		public void add_header (string name, string val) {
 			raw_headers.append (name, val);
 		}

--- a/lib/base/xnu-syscalls/xnu-syscalls.vala
+++ b/lib/base/xnu-syscalls/xnu-syscalls.vala
@@ -16,6 +16,9 @@ namespace Frida {
 		public string? name;
 	}
 
+	/**
+	 * The XNU Mach trap numbers, as used on Apple platforms.
+	 */
 	public enum XnuMachTrap {
 		MACH_VM_ALLOCATE = -10,
 		MACH_VM_PURGABLE_CONTROL = -11,
@@ -81,6 +84,9 @@ namespace Frida {
 		IOKIT_USER_CLIENT = -100,
 	}
 
+	/**
+	 * The XNU BSD syscall numbers, as used on Apple platforms.
+	 */
 	public enum XnuBsdSyscall {
 		EXIT = 1,
 		FORK = 2,

--- a/src/api/generate.py
+++ b/src/api/generate.py
@@ -303,7 +303,7 @@ def build_doc_index(src_dir: Path) -> DocIndex:
             sources.append(path.read_text(encoding="utf-8"))
     base_dir = src_dir.parent / "lib" / "base"
     if base_dir.is_dir():
-        for path in sorted(base_dir.glob("*.vala")):
+        for path in sorted(base_dir.rglob("*.vala")):
             sources.append(path.read_text(encoding="utf-8"))
 
     index = DocIndex(types={}, members={}, enum_members={})

--- a/src/api/generate.py
+++ b/src/api/generate.py
@@ -89,7 +89,7 @@ def main():
         emit_header(api, output_dir)
 
     if enable_gir:
-        emit_gir(api, core_gir, base_gir, output_dir)
+        emit_gir(api, core_gir, base_gir, output_dir, build_doc_index(src_dir))
 
     if enable_vapi:
         emit_vapi(api, output_dir)
@@ -195,7 +195,7 @@ def emit_header(api, output_dir):
 
         output_header_file.write("\n\n#endif\n")
 
-def emit_gir(api: ApiSpec, core_gir: str, base_gir: str, output_dir: Path) -> str:
+def emit_gir(api: ApiSpec, core_gir: str, base_gir: str, output_dir: Path, docs: DocIndex) -> str:
     ET.register_namespace("", CORE_NAMESPACE)
     ET.register_namespace("c", C_NAMESPACE)
     ET.register_namespace("glib", GLIB_NAMESPACE)
@@ -264,6 +264,8 @@ def emit_gir(api: ApiSpec, core_gir: str, base_gir: str, output_dir: Path) -> st
             if callback.get("name") in needed_names:
                 merged_namespace.append(callback)
 
+    inject_documentation(merged_namespace, docs)
+
     ET.indent(merged_root, space="  ")
     result = ET.tostring(merged_root,
                          encoding="unicode",
@@ -274,6 +276,312 @@ def emit_gir(api: ApiSpec, core_gir: str, base_gir: str, output_dir: Path) -> st
 
 def filter_elements(elements: List[ET.Element], spec_set: Set[str]):
     return [elem for elem in elements if elem.get("name") in spec_set]
+
+@dataclass
+class DocComment:
+    body: str
+    params: dict
+    returns: str
+
+@dataclass
+class DocIndex:
+    types: dict          # type_name -> DocComment
+    members: dict        # (type_name, member_name) -> DocComment
+    enum_members: dict   # (enum_name, member_name) -> DocComment
+
+DOC_TYPE_PATTERN = re.compile(r"public\s+(?:sealed\s+|abstract\s+)?(class|interface|enum|errordomain)\s+(\w+)")
+DOC_SIGNAL_PATTERN = re.compile(r"public\s+signal\s+\S.*?\b(\w+)\s*\(")
+DOC_PROPERTY_PATTERN = re.compile(r"public\s+(?:unowned\s+)?\S.*?\b(\w+)\s*\{")
+DOC_METHOD_PATTERN = re.compile(r"public\s+\S.*?\b(\w+)\s*\(")
+DOC_ENUM_MEMBER_PATTERN = re.compile(r"([A-Z][A-Z0-9_]*)\b")
+
+def build_doc_index(src_dir: Path) -> DocIndex:
+    sources = []
+    for name in TOPLEVEL_NAMES:
+        path = src_dir / name
+        if path.exists():
+            sources.append(path.read_text(encoding="utf-8"))
+    base_dir = src_dir.parent / "lib" / "base"
+    if base_dir.is_dir():
+        for path in sorted(base_dir.glob("*.vala")):
+            sources.append(path.read_text(encoding="utf-8"))
+
+    index = DocIndex(types={}, members={}, enum_members={})
+    for source in sources:
+        _collect_docs_from_source(source, index)
+    return index
+
+def _collect_docs_from_source(source: str, index: DocIndex):
+    lines = source.split("\n")
+    pending = None
+    current_type = None
+    current_is_enum = False
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        stripped = line.strip()
+
+        if stripped.startswith("/**"):
+            block = [line]
+            while "*/" not in lines[i]:
+                i += 1
+                block.append(lines[i])
+            pending = _parse_doc_block(block)
+            i += 1
+            continue
+
+        if stripped == "" or stripped.startswith("//") or stripped.startswith("["):
+            i += 1
+            continue
+
+        indent = len(line) - len(line.lstrip("\t"))
+
+        type_match = DOC_TYPE_PATTERN.match(stripped)
+        if indent == 1 and type_match is not None:
+            current_type = type_match.group(2)
+            current_is_enum = type_match.group(1) in ("enum", "errordomain")
+            if pending is not None:
+                index.types[current_type] = pending
+            pending = None
+            i += 1
+            continue
+
+        if pending is not None and current_type is not None and indent >= 2:
+            if current_is_enum:
+                member_match = DOC_ENUM_MEMBER_PATTERN.match(stripped)
+                if member_match is not None:
+                    index.enum_members[(current_type, member_match.group(1))] = pending
+            else:
+                name = _parse_member_name(stripped, current_type)
+                if name is not None:
+                    index.members[(current_type, name)] = pending
+            pending = None
+            i += 1
+            continue
+
+        pending = None
+        i += 1
+
+def _parse_member_name(stripped: str, type_name: str):
+    if not stripped.startswith("public"):
+        return None
+    signal_match = DOC_SIGNAL_PATTERN.match(stripped)
+    if signal_match is not None:
+        return signal_match.group(1)
+    brace = stripped.find("{")
+    if brace != -1 and "(" not in stripped[:brace]:
+        property_match = DOC_PROPERTY_PATTERN.match(stripped)
+        if property_match is not None:
+            return property_match.group(1)
+    ctor_match = re.match(r"public\s+" + re.escape(type_name) + r"(?:\.(\w+))?\s*\(", stripped)
+    if ctor_match is not None:
+        return "new" if ctor_match.group(1) is None else ctor_match.group(1)
+    method_match = DOC_METHOD_PATTERN.match(stripped)
+    if method_match is not None:
+        return method_match.group(1)
+    return None
+
+def _parse_doc_block(block: List[str]) -> DocComment:
+    text_lines = []
+    for raw in block:
+        s = raw.strip()
+        if s.startswith("/**"):
+            s = s[3:]
+        if s.endswith("*/"):
+            s = s[:-2]
+        s = s.strip()
+        if s.startswith("*"):
+            s = s[1:]
+            if s.startswith(" "):
+                s = s[1:]
+        text_lines.append(s.rstrip())
+
+    # Valadoc block tags: "@param <name> <description>" and "@return <description>".
+    body_lines = []
+    params = {}
+    returns_lines = []
+    target = body_lines
+    for line in text_lines:
+        param_match = re.match(r"@param\s+(\w+)\s*(.*)", line)
+        return_match = re.match(r"@returns?\s*(.*)", line)
+        if param_match is not None:
+            params[param_match.group(1)] = [param_match.group(2)]
+            target = params[param_match.group(1)]
+            continue
+        if return_match is not None:
+            returns_lines = [return_match.group(1)]
+            target = returns_lines
+            continue
+        target.append(line)
+
+    def finish(lines):
+        return _valadoc_to_markdown("\n".join(lines).strip())
+
+    return DocComment(
+        body=finish(body_lines),
+        params={k: finish(v) for k, v in params.items()},
+        returns=finish(returns_lines),
+    )
+
+def _valadoc_to_markdown(text: str) -> str:
+    if not text:
+        return text
+    # Code blocks: {{{ ... }}} -> fenced ``` blocks.
+    def code_block(match):
+        code = match.group(1).strip("\n")
+        return "\n```\n" + code + "\n```\n"
+    text = re.sub(r"\{\{\{(.*?)\}\}\}", code_block, text, flags=re.DOTALL)
+    # Note: {@link ...} cross-references are resolved later, at injection time,
+    # where the full symbol table is available (see inject_documentation).
+    # Inline monospace: ``x`` -> `x` (valadoc) is already markdown-compatible.
+    # Bold: ''x'' -> **x**.
+    text = re.sub(r"''(.+?)''", r"**\1**", text)
+    # Italic: //x// -> *x*, but leave protocol-relative URLs (://) alone.
+    text = re.sub(r"(?<![:/])//(?!/)(.+?)//", r"*\1*", text)
+    return text
+
+def inject_documentation(merged_namespace: ET.Element, docs: DocIndex):
+    glib_signal_tag = f"{{{GLIB_NAMESPACE}}}signal"
+    callable_tags = {
+        f"{{{CORE_NAMESPACE}}}method",
+        f"{{{CORE_NAMESPACE}}}constructor",
+        f"{{{CORE_NAMESPACE}}}function",
+        f"{{{CORE_NAMESPACE}}}virtual-method",
+        glib_signal_tag,
+    }
+    property_tag = f"{{{CORE_NAMESPACE}}}property"
+    member_tag = f"{{{CORE_NAMESPACE}}}member"
+    doc_tag = f"{{{CORE_NAMESPACE}}}doc"
+
+    # Build a symbol table so {@link ...} can be turned into real gi-docgen
+    # cross-references. Keys use Vala-style names (underscores); values carry the
+    # gi-docgen link kind and the GIR name (dashes for properties/signals).
+    type_kinds = {}      # type_name -> gi-docgen kind ("class"/"iface"/"enum"/"error")
+    member_kinds = {}    # (type_name, vala_member) -> (kind, gir_name)
+    for type_elem in list(merged_namespace):
+        type_name = type_elem.get("name")
+        if type_name is None:
+            continue
+        tag = type_elem.tag.split("}")[-1]
+        if tag == "class":
+            type_kinds[type_name] = "class"
+        elif tag == "interface":
+            type_kinds[type_name] = "iface"
+        elif tag == "enumeration":
+            type_kinds[type_name] = "error" \
+                if type_elem.get(f"{{{GLIB_NAMESPACE}}}error-domain") is not None \
+                else "enum"
+        for child in list(type_elem):
+            cname = child.get("name")
+            if cname is None:
+                continue
+            if child.tag == f"{{{CORE_NAMESPACE}}}method":
+                member_kinds[(type_name, cname)] = ("method", cname)
+            elif child.tag == f"{{{CORE_NAMESPACE}}}constructor":
+                member_kinds[(type_name, cname)] = ("ctor", cname)
+            elif child.tag == property_tag:
+                member_kinds[(type_name, cname.replace("-", "_"))] = ("property", cname)
+            elif child.tag == glib_signal_tag:
+                member_kinds[(type_name, cname.replace("-", "_"))] = ("signal", cname)
+
+    def resolve_links(text: str) -> str:
+        def repl(match):
+            target = re.sub(r"^Frida\.", "", match.group(1).strip())
+            parts = target.split(".")
+            if len(parts) == 1:
+                kind = type_kinds.get(parts[0])
+                if kind is not None:
+                    return f"[{kind}@Frida.{parts[0]}]"
+            elif len(parts) == 2:
+                info = member_kinds.get((parts[0], parts[1]))
+                if info is not None:
+                    kind, gir_name = info
+                    if kind == "method":
+                        return f"[method@Frida.{parts[0]}.{gir_name}]"
+                    if kind == "ctor":
+                        return f"[ctor@Frida.{parts[0]}.{gir_name}]"
+                    if kind == "property":
+                        return f"[property@Frida.{parts[0]}:{gir_name}]"
+                    if kind == "signal":
+                        return f"[signal@Frida.{parts[0]}::{gir_name}]"
+            return "`" + target + "`"
+        return re.sub(r"\{@link\s+([^}]+)\}", repl, text)
+
+    def set_doc(elem: ET.Element, text: str):
+        if not text:
+            return
+        if elem.find(doc_tag) is not None:
+            return
+        doc = ET.Element(doc_tag)
+        doc.set("xml:space", "preserve")
+        doc.text = resolve_links(text)
+        elem.insert(0, doc)
+
+    def member_doc(type_name: str, name: str):
+        comment = docs.members.get((type_name, name))
+        if comment is None:
+            for suffix in ("_finish", "_sync"):
+                if name.endswith(suffix):
+                    comment = docs.members.get((type_name, name[: -len(suffix)]))
+                    if comment is not None:
+                        break
+        return comment
+
+    def apply_callable(elem: ET.Element, comment: DocComment):
+        set_doc(elem, comment.body)
+        if comment.returns:
+            rv = elem.find(f"{{{CORE_NAMESPACE}}}return-value")
+            if rv is not None:
+                set_doc(rv, comment.returns)
+        params_elem = elem.find(f"{{{CORE_NAMESPACE}}}parameters")
+        if params_elem is not None and comment.params:
+            for param in params_elem.findall(f"{{{CORE_NAMESPACE}}}parameter"):
+                text = comment.params.get(param.get("name"))
+                if text:
+                    set_doc(param, text)
+
+    for type_elem in list(merged_namespace):
+        type_name = type_elem.get("name")
+        if type_name is None:
+            continue
+        tag = type_elem.tag.split("}")[-1]
+
+        type_comment = docs.types.get(type_name)
+        if type_comment is not None and tag in ("class", "interface", "enumeration"):
+            set_doc(type_elem, type_comment.body)
+
+        for child in list(type_elem):
+            child_name = child.get("name")
+            if child_name is None:
+                continue
+            if child.tag in callable_tags:
+                lookup = child_name.replace("-", "_") if child.tag == glib_signal_tag \
+                    else child_name
+                comment = member_doc(type_name, lookup)
+                if comment is not None:
+                    apply_callable(child, comment)
+                elif child.tag == f"{{{CORE_NAMESPACE}}}constructor" \
+                        and child_name == "new":
+                    # Vala's implicit default constructor; give it a sensible
+                    # description rather than leaving it bare.
+                    set_doc(child, f"Creates a new [class@Frida.{type_name}].")
+            elif child.tag == property_tag:
+                vala_name = child_name.replace("-", "_")
+                comment = docs.members.get((type_name, vala_name))
+                if comment is not None:
+                    set_doc(child, comment.body)
+                    # The C API also exposes the property through getter/setter
+                    # methods; give them the same description.
+                    accessors = {"get_" + vala_name, "set_" + vala_name}
+                    for sibling in type_elem:
+                        if sibling.tag == f"{{{CORE_NAMESPACE}}}method" \
+                                and sibling.get("name") in accessors:
+                            set_doc(sibling, comment.body)
+            elif child.tag == member_tag:
+                comment = docs.enum_members.get((type_name, child_name.upper()))
+                if comment is not None:
+                    set_doc(child, comment.body)
 
 def emit_vapi(api, output_dir):
     with OutputFile(output_dir / f"frida-core-{api.version}.vapi") as output_vapi_file:

--- a/src/compiler/compiler.vala
+++ b/src/compiler/compiler.vala
@@ -1,8 +1,28 @@
 namespace Frida {
+	/**
+	 * Compiles a TypeScript or JavaScript project into a single script bundle
+	 * that can be loaded with {@link Session.create_script}.
+	 */
 	public sealed class Compiler : Object {
+		/**
+		 * Emitted when a build is starting.
+		 */
 		public signal void starting ();
+		/**
+		 * Emitted when a build has finished.
+		 */
 		public signal void finished ();
+		/**
+		 * Emitted with the freshly built bundle, primarily when watching.
+		 *
+		 * @param bundle the compiled script bundle
+		 */
 		public signal void output (string bundle);
+		/**
+		 * Emitted with compiler diagnostics, such as type errors and warnings.
+		 *
+		 * @param diagnostics the diagnostics, as a variant
+		 */
 		public signal void diagnostics (Variant diagnostics);
 
 		private size_t watch_session_handle = 0;
@@ -11,6 +31,11 @@ namespace Frida {
 		private MainContext main_context;
 
 		// TODO: Remove the DeviceManager parameter.
+		/**
+		 * Creates a compiler.
+		 *
+		 * @param manager unused; kept for compatibility
+		 */
 		public Compiler (DeviceManager? manager = null) {
 			Object ();
 		}
@@ -27,6 +52,13 @@ namespace Frida {
 			cancel_watch ();
 		}
 
+		/**
+		 * Builds the project rooted at @entrypoint once.
+		 *
+		 * @param entrypoint path to the project's entrypoint module
+		 * @param options build options, or null for the defaults
+		 * @return the compiled script bundle
+		 */
 		public async string build (string entrypoint, BuildOptions? options = null, Cancellable? cancellable = null)
 				throws Error, IOError {
 			CompilerBackend.check_available ();
@@ -78,6 +110,13 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Builds the project and keeps rebuilding it as its sources change,
+		 * emitting {@link Compiler.output} with each fresh bundle.
+		 *
+		 * @param entrypoint path to the project's entrypoint module
+		 * @param options watch options, or null for the defaults
+		 */
 		public async void watch (string entrypoint, WatchOptions? options = null, Cancellable? cancellable = null)
 				throws Error, IOError {
 			CompilerBackend.check_available ();
@@ -980,42 +1019,66 @@ namespace Frida {
 		return Environment.get_current_dir ();
 	}
 
+	/**
+	 * Options shared by {@link Compiler.build} and {@link Compiler.watch}.
+	 */
 	public class CompilerOptions : Object {
+		/**
+		 * The project root directory, or null to infer it from the entrypoint.
+		 */
 		public string? project_root {
 			get;
 			set;
 		}
 
+		/**
+		 * How the resulting bundle's bytes are encoded.
+		 */
 		public OutputFormat output_format {
 			get;
 			set;
 			default = UNESCAPED;
 		}
 
+		/**
+		 * The module format of the bundle.
+		 */
 		public BundleFormat bundle_format {
 			get;
 			set;
 			default = ESM;
 		}
 
+		/**
+		 * Whether to type-check the project.
+		 */
 		public TypeCheckMode type_check {
 			get;
 			set;
 			default = FULL;
 		}
 
+		/**
+		 * Whether to include source maps in the bundle.
+		 */
 		public SourceMaps source_maps {
 			get;
 			set;
 			default = INCLUDED;
 		}
 
+		/**
+		 * Which compressor to run the output through, if any.
+		 */
 		public JsCompression compression {
 			get;
 			set;
 			default = NONE;
 		}
 
+		/**
+		 * Which platform the bundle targets.
+		 */
 		public JsPlatform platform {
 			get;
 			set;
@@ -1024,29 +1087,60 @@ namespace Frida {
 
 		internal Gee.List<string> externals = new Gee.ArrayList<string> ();
 
+		/**
+		 * Removes all configured externals.
+		 */
 		public void clear_externals () {
 			externals.clear ();
 		}
 
+		/**
+		 * Marks a module as external, leaving it out of the bundle.
+		 *
+		 * @param external the module specifier to treat as external
+		 */
 		public void add_external (string external) {
 			externals.add (external);
 		}
 
+		/**
+		 * Invokes @func for each configured external.
+		 *
+		 * @param func function called with each external
+		 */
 		public void enumerate_externals (Func<string> func) {
 			foreach (var external in externals)
 				func (external);
 		}
 	}
 
+	/**
+	 * Options for {@link Compiler.build}.
+	 */
 	public sealed class BuildOptions : CompilerOptions {
 	}
 
+	/**
+	 * Options for {@link Compiler.watch}.
+	 */
 	public sealed class WatchOptions : CompilerOptions {
 	}
 
+	/**
+	 * How a compiled bundle's bytes are encoded.
+	 */
 	public enum OutputFormat {
+		/**
+		 * Raw, unescaped JavaScript.
+		 */
 		UNESCAPED,
+		/**
+		 * A hex-encoded byte string.
+		 */
 		HEX_BYTES,
+		/**
+		 * A C string literal.
+		 */
 		C_STRING;
 
 		public static OutputFormat from_nick (string nick) throws Error {
@@ -1058,8 +1152,17 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * The module format of a compiled bundle.
+	 */
 	public enum BundleFormat {
+		/**
+		 * An ECMAScript module.
+		 */
 		ESM,
+		/**
+		 * An immediately-invoked function expression.
+		 */
 		IIFE;
 
 		public static BundleFormat from_nick (string nick) throws Error {
@@ -1071,8 +1174,17 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * Whether the compiler type-checks the project.
+	 */
 	public enum TypeCheckMode {
+		/**
+		 * Perform full type checking.
+		 */
 		FULL,
+		/**
+		 * Skip type checking.
+		 */
 		NONE;
 
 		public static TypeCheckMode from_nick (string nick) throws Error {
@@ -1084,8 +1196,17 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * Whether source maps are included in a compiled bundle.
+	 */
 	public enum SourceMaps {
+		/**
+		 * Include source maps.
+		 */
 		INCLUDED,
+		/**
+		 * Omit source maps.
+		 */
 		OMITTED;
 
 		public static SourceMaps from_nick (string nick) throws Error {
@@ -1097,8 +1218,17 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * Which compressor the compiled JavaScript is run through.
+	 */
 	public enum JsCompression {
+		/**
+		 * No compression.
+		 */
 		NONE,
+		/**
+		 * Compress with Terser.
+		 */
 		TERSER;
 
 		public static JsCompression from_nick (string nick) throws Error {
@@ -1110,9 +1240,21 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * The platform a compiled bundle targets.
+	 */
 	public enum JsPlatform {
+		/**
+		 * Frida's Gum runtime inside a target process.
+		 */
 		GUM,
+		/**
+		 * A web browser.
+		 */
 		BROWSER,
+		/**
+		 * A platform-neutral environment.
+		 */
 		NEUTRAL;
 
 		public static JsPlatform from_nick (string nick) throws Error {

--- a/src/control-service.vala
+++ b/src/control-service.vala
@@ -1,10 +1,20 @@
 namespace Frida {
+	/**
+	 * Hosts a Frida control endpoint that frida-server-style clients can connect
+	 * to, exposing the local system over the network.
+	 */
 	public sealed class ControlService : Object {
+		/**
+		 * The endpoint the service listens on.
+		 */
 		public EndpointParameters endpoint_params {
 			get;
 			construct;
 		}
 
+		/**
+		 * The options the service was configured with.
+		 */
 		public ControlServiceOptions options {
 			get;
 			construct;
@@ -39,6 +49,12 @@ namespace Frida {
 			STOPPING
 		}
 
+		/**
+		 * Creates a control service listening on the given endpoint.
+		 *
+		 * @param endpoint_params the endpoint to listen on
+		 * @param options service options, or null for the defaults
+		 */
 		public ControlService (EndpointParameters endpoint_params, ControlServiceOptions? options = null) throws Error {
 #if HAVE_LOCAL_BACKEND
 			ControlServiceOptions opts = (options != null) ? options : new ControlServiceOptions ();
@@ -73,6 +89,14 @@ namespace Frida {
 #endif
 		}
 
+		/**
+		 * Creates a control service exposing a specific device rather than the
+		 * local system.
+		 *
+		 * @param device the device to expose
+		 * @param endpoint_params the endpoint to listen on
+		 * @param options service options, or null for the defaults
+		 */
 		public async ControlService.with_device (Device device, EndpointParameters endpoint_params,
 				ControlServiceOptions? options = null, Cancellable? cancellable = null) throws Error, IOError {
 			ControlServiceOptions opts = (options != null) ? options : new ControlServiceOptions ();
@@ -111,6 +135,9 @@ namespace Frida {
 			this.provider = provider;
 		}
 
+		/**
+		 * Starts the service, binding the endpoint and accepting clients.
+		 */
 		public async void start (Cancellable? cancellable = null) throws Error, IOError {
 			if (state != STOPPED)
 				throw new Error.INVALID_OPERATION ("Invalid operation");
@@ -146,6 +173,9 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Stops the service, disconnecting clients and releasing the endpoint.
+		 */
 		public async void stop (Cancellable? cancellable = null) throws Error, IOError {
 			if (state != STARTED)
 				throw new Error.INVALID_OPERATION ("Invalid operation");
@@ -1124,13 +1154,22 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * Options for a {@link ControlService}.
+	 */
 	public sealed class ControlServiceOptions : Object {
+		/**
+		 * Whether to preload the agent for faster first attach.
+		 */
 		public bool enable_preload {
 			get;
 			set;
 			default = true;
 		}
 
+		/**
+		 * Whether to capture and report crashes in instrumented processes.
+		 */
 		public bool report_crashes {
 			get;
 			set;

--- a/src/file-monitor.vala
+++ b/src/file-monitor.vala
@@ -1,7 +1,21 @@
 namespace Frida {
+	/**
+	 * Watches a filesystem path and reports changes to it.
+	 */
 	public sealed class FileMonitor : Object {
+		/**
+		 * Emitted when a change is observed at the watched path.
+		 *
+		 * @param file_path the path that changed
+		 * @param other_file_path the other path involved, for example the
+		 *   destination of a rename, or null
+		 * @param event the kind of change
+		 */
 		public signal void change (string file_path, string? other_file_path, FileMonitorEvent event);
 
+		/**
+		 * The path being watched.
+		 */
 		public string path {
 			get;
 			construct;
@@ -9,6 +23,11 @@ namespace Frida {
 
 		private GLib.FileMonitor monitor;
 
+		/**
+		 * Creates a file monitor for the given path.
+		 *
+		 * @param path the filesystem path to watch
+		 */
 		public FileMonitor (string path) {
 			Object (path: path);
 		}
@@ -17,6 +36,10 @@ namespace Frida {
 			clear ();
 		}
 
+		/**
+		 * Starts watching, after which {@link FileMonitor.change} is emitted on
+		 * each change.
+		 */
 		public async void enable (Cancellable? cancellable = null) throws Error, IOError {
 			if (monitor != null)
 				throw new Error.INVALID_OPERATION ("Already enabled");
@@ -43,6 +66,9 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Stops watching.
+		 */
 		public async void disable (Cancellable? cancellable = null) throws Error, IOError {
 			if (monitor == null)
 				throw new Error.INVALID_OPERATION ("Already disabled");

--- a/src/frida.vala
+++ b/src/frida.vala
@@ -11,8 +11,17 @@ namespace Frida {
 	public extern void version (out uint major, out uint minor, out uint micro, out uint nano);
 	public extern unowned string version_string ();
 
+	/**
+	 * Selects which main-loop runtime Frida integrates with.
+	 */
 	public enum Runtime {
+		/**
+		 * Use GLib's own main loop.
+		 */
 		GLIB,
+		/**
+		 * Integrate with a foreign runtime that hosts GLib.
+		 */
 		OTHER;
 
 		public static Runtime from_nick (string nick) throws Error {
@@ -24,11 +33,38 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * Enumerates and keeps track of the devices available to Frida, and is the
+	 * usual entry point of the API.
+	 *
+	 * Create one, then obtain a {@link Device} — for example the local system
+	 * via {@link DeviceManager.get_device_by_type} with
+	 * {@link DeviceType.LOCAL}, or a USB-connected device.
+	 */
 	public sealed class DeviceManager : Object, HostSessionHub {
+		/**
+		 * Emitted when a device is added, such as when a phone is plugged in.
+		 *
+		 * @param device the device that appeared
+		 */
 		public signal void added (Device device);
+		/**
+		 * Emitted when a device is removed, such as when a phone is unplugged.
+		 *
+		 * @param device the device that went away
+		 */
 		public signal void removed (Device device);
+		/**
+		 * Emitted when the set of available devices changes.
+		 */
 		public signal void changed ();
 
+		/**
+		 * Predicate deciding whether a device matches.
+		 *
+		 * @param device the device to test
+		 * @return true if @device matches
+		 */
 		public delegate bool Predicate (Device device);
 
 		private Promise<bool>? start_request;
@@ -40,18 +76,33 @@ namespace Frida {
 
 		private Cancellable io_cancellable = new Cancellable ();
 
+		/**
+		 * Creates a new device manager with all backends enabled.
+		 */
 		public DeviceManager () {
 			service = new HostSessionService.with_default_backends ();
 		}
 
+		/**
+		 * Creates a device manager with only the non-local backends enabled, so
+		 * the local system is not exposed as a device.
+		 */
 		public DeviceManager.with_nonlocal_backends_only () {
 			service = new HostSessionService.with_nonlocal_backends_only ();
 		}
 
+		/**
+		 * Creates a device manager with only the socket backend enabled, for
+		 * connecting to remote devices over the network.
+		 */
 		public DeviceManager.with_socket_backend_only () {
 			service = new HostSessionService.with_socket_backend_only ();
 		}
 
+		/**
+		 * Closes the device manager, releasing all resources. The instance must
+		 * not be used afterwards.
+		 */
 		public async void close (Cancellable? cancellable = null) throws IOError {
 			yield stop_service (cancellable);
 		}
@@ -70,6 +121,13 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Gets the device with the given ID, throwing if it cannot be found.
+		 *
+		 * @param id the device identifier
+		 * @param timeout milliseconds to wait for a match, or 0 to not wait
+		 * @return the matching device
+		 */
 		public async Device get_device_by_id (string id, int timeout = 0, Cancellable? cancellable = null) throws Error, IOError {
 			return check_device (yield find_device_by_id (id, timeout, cancellable));
 		}
@@ -78,6 +136,13 @@ namespace Frida {
 			return check_device (find_device_by_id_sync (id, timeout, cancellable));
 		}
 
+		/**
+		 * Gets the first device of the given type, throwing if none is found.
+		 *
+		 * @param type the kind of device to look for
+		 * @param timeout milliseconds to wait for a match, or 0 to not wait
+		 * @return the matching device
+		 */
 		public async Device get_device_by_type (DeviceType type, int timeout = 0, Cancellable? cancellable = null)
 				throws Error, IOError {
 			return check_device (yield find_device_by_type (type, timeout, cancellable));
@@ -88,6 +153,14 @@ namespace Frida {
 			return check_device (find_device_by_type_sync (type, timeout, cancellable));
 		}
 
+		/**
+		 * Gets the first device accepted by @predicate, throwing if none is
+		 * found.
+		 *
+		 * @param predicate function deciding whether a device matches
+		 * @param timeout milliseconds to wait for a match, or 0 to not wait
+		 * @return the matching device
+		 */
 		public async Device get_device (Predicate predicate, int timeout = 0, Cancellable? cancellable = null)
 				throws Error, IOError {
 			return check_device (yield find_device (predicate, timeout, cancellable));
@@ -104,6 +177,13 @@ namespace Frida {
 			return device;
 		}
 
+		/**
+		 * Finds the device with the given ID.
+		 *
+		 * @param id the device identifier
+		 * @param timeout milliseconds to wait for a match, or 0 to not wait
+		 * @return the device, or null if not found
+		 */
 		public async Device? find_device_by_id (string id, int timeout = 0, Cancellable? cancellable = null) throws Error, IOError {
 			return yield find_device ((device) => { return device.id == id; }, timeout, cancellable);
 		}
@@ -112,6 +192,13 @@ namespace Frida {
 			return find_device_sync ((device) => { return device.id == id; }, timeout, cancellable);
 		}
 
+		/**
+		 * Finds the first device of the given type.
+		 *
+		 * @param type the kind of device to look for
+		 * @param timeout milliseconds to wait for a match, or 0 to not wait
+		 * @return the device, or null if not found
+		 */
 		public async Device? find_device_by_type (DeviceType type, int timeout = 0, Cancellable? cancellable = null)
 				throws Error, IOError {
 			return yield find_device ((device) => { return device.dtype == type; }, timeout, cancellable);
@@ -122,6 +209,13 @@ namespace Frida {
 			return find_device_sync ((device) => { return device.dtype == type; }, timeout, cancellable);
 		}
 
+		/**
+		 * Finds the first device accepted by @predicate.
+		 *
+		 * @param predicate function deciding whether a device matches
+		 * @param timeout milliseconds to wait for a match, or 0 to not wait
+		 * @return the device, or null if not found
+		 */
 		public async Device? find_device (Predicate predicate, int timeout = 0, Cancellable? cancellable = null)
 				throws Error, IOError {
 			check_open ();
@@ -198,6 +292,11 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Enumerates the currently available devices.
+		 *
+		 * @return the available devices
+		 */
 		public async DeviceList enumerate_devices (Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
 
@@ -216,6 +315,14 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Adds a device reachable over the network at the given address.
+		 *
+		 * @param address the host and optional port to connect to
+		 * @param options connection options, such as TLS and authentication, or
+		 *   null
+		 * @return the newly added device
+		 */
 		public async Device add_remote_device (string address, RemoteDeviceOptions? options = null,
 				Cancellable? cancellable = null) throws Error, IOError {
 #if HAVE_SOCKET_BACKEND
@@ -283,6 +390,12 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Removes a remote device previously added with
+		 * {@link DeviceManager.add_remote_device}.
+		 *
+		 * @param address the address the device was added with
+		 */
 		public async void remove_remote_device (string address, Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
 
@@ -468,6 +581,9 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * An immutable list of {@link Device} objects.
+	 */
 	public sealed class DeviceList : Object {
 		private Gee.List<Device> items;
 
@@ -475,25 +591,86 @@ namespace Frida {
 			this.items = items;
 		}
 
+		/**
+		 * Gets the number of devices in the list.
+		 *
+		 * @return the count
+		 */
 		public int size () {
 			return items.size;
 		}
 
+		/**
+		 * Gets the device at the given position.
+		 *
+		 * @param index zero-based position
+		 * @return the device
+		 */
 		public new Device get (int index) {
 			return items.get (index);
 		}
 	}
 
+	/**
+	 * Represents a device that Frida can interact with, such as the local
+	 * system, a USB-connected phone, or a remote frida-server.
+	 *
+	 * Obtain one through a {@link DeviceManager}, then use it to spawn or attach
+	 * to processes.
+	 */
 	public sealed class Device : Object {
+		/**
+		 * Emitted when a process is spawned while spawn gating is enabled.
+		 *
+		 * @param spawn details of the pending spawn
+		 */
 		public signal void spawn_added (Spawn spawn);
+		/**
+		 * Emitted when a pending spawn is resumed or killed.
+		 *
+		 * @param spawn the spawn that is no longer pending
+		 */
 		public signal void spawn_removed (Spawn spawn);
+		/**
+		 * Emitted when a new child is observed while child gating is enabled.
+		 *
+		 * @param child details of the child process
+		 */
 		public signal void child_added (Child child);
+		/**
+		 * Emitted when a previously added child is resumed or has gone away.
+		 *
+		 * @param child the child that is no longer pending
+		 */
 		public signal void child_removed (Child child);
+		/**
+		 * Emitted when a process crashes.
+		 *
+		 * @param crash details of the crash
+		 */
 		public signal void process_crashed (Crash crash);
+		/**
+		 * Emitted when a spawned process writes to its standard output or error.
+		 *
+		 * @param pid the process ID
+		 * @param fd the file descriptor written to (1 for stdout, 2 for stderr)
+		 * @param data the bytes written, or an empty buffer on EOF
+		 */
 		public signal void output (uint pid, int fd, Bytes data);
+		/**
+		 * Emitted when an injected library has been unloaded.
+		 *
+		 * @param id the injection ID returned when the library was injected
+		 */
 		public signal void uninjected (uint id);
+		/**
+		 * Emitted when the connection to the device is lost.
+		 */
 		public signal void lost ();
 
+		/**
+		 * The device's stable identifier.
+		 */
 		public string id {
 			get {
 				if (_id != null)
@@ -502,6 +679,9 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * The device's human-readable name.
+		 */
 		public string name {
 			get {
 				if (_name != null)
@@ -510,11 +690,18 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * An icon representing the device, serialized as a variant, or null if
+		 * none is available.
+		 */
 		public Variant? icon {
 			get;
 			construct;
 		}
 
+		/**
+		 * The kind of device: local, remote, or USB.
+		 */
 		public DeviceType dtype {
 			get {
 				switch (provider.kind) {
@@ -530,6 +717,9 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * The device's message bus, for exchanging messages with the device.
+		 */
 		public Bus bus {
 			get {
 				return _bus;
@@ -577,10 +767,21 @@ namespace Frida {
 			provider.agent_session_detached.connect (on_agent_session_detached);
 		}
 
+		/**
+		 * Checks whether the connection to the device has been lost.
+		 *
+		 * @return true if the device is no longer reachable
+		 */
 		public bool is_lost () {
 			return close_request != null;
 		}
 
+		/**
+		 * Overrides a device-level option.
+		 *
+		 * @param name the option name
+		 * @param val the value to set
+		 */
 		public void override_option (string name, Variant val) throws Error {
 			Value v;
 			switch (val.classify ()) {
@@ -615,6 +816,12 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Queries a set of parameters describing the device and its operating
+		 * system.
+		 *
+		 * @return a table of system parameters keyed by name
+		 */
 		public async HashTable<string, Variant> query_system_parameters (Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
 
@@ -637,6 +844,12 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Gets the application currently in the foreground, if any.
+		 *
+		 * @param options query options shaping the returned details, or null
+		 * @return the frontmost application, or null if none
+		 */
 		public async Application? get_frontmost_application (FrontmostQueryOptions? options = null,
 				Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
@@ -672,6 +885,12 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Enumerates the applications installed on the device.
+		 *
+		 * @param options query options to scope and shape the results, or null
+		 * @return the matching applications
+		 */
 		public async ApplicationList enumerate_applications (ApplicationQueryOptions? options = null,
 				Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
@@ -708,6 +927,13 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Gets the process with the given PID, throwing if it cannot be found.
+		 *
+		 * @param pid the process ID
+		 * @param options matching options, such as a scope or timeout, or null
+		 * @return the matching process
+		 */
 		public async Process get_process_by_pid (uint pid, ProcessMatchOptions? options = null,
 				Cancellable? cancellable = null) throws Error, IOError {
 			return check_process (yield find_process_by_pid (pid, options, cancellable));
@@ -718,6 +944,13 @@ namespace Frida {
 			return check_process (find_process_by_pid_sync (pid, options, cancellable));
 		}
 
+		/**
+		 * Gets the process whose name matches, throwing if none is found.
+		 *
+		 * @param name the process name to match
+		 * @param options matching options, or null
+		 * @return the matching process
+		 */
 		public async Process get_process_by_name (string name, ProcessMatchOptions? options = null,
 				Cancellable? cancellable = null) throws Error, IOError {
 			return check_process (yield find_process_by_name (name, options, cancellable));
@@ -728,6 +961,14 @@ namespace Frida {
 			return check_process (find_process_by_name_sync (name, options, cancellable));
 		}
 
+		/**
+		 * Gets the first process accepted by @predicate, throwing if none is
+		 * found.
+		 *
+		 * @param predicate function deciding whether a process matches
+		 * @param options matching options, or null
+		 * @return the matching process
+		 */
 		public async Process get_process (ProcessPredicate predicate, ProcessMatchOptions? options = null,
 				Cancellable? cancellable = null) throws Error, IOError {
 			return check_process (yield find_process (predicate, options, cancellable));
@@ -744,6 +985,13 @@ namespace Frida {
 			return process;
 		}
 
+		/**
+		 * Finds the process with the given PID.
+		 *
+		 * @param pid the process ID
+		 * @param options matching options, or null
+		 * @return the process, or null if not found
+		 */
 		public async Process? find_process_by_pid (uint pid, ProcessMatchOptions? options = null,
 				Cancellable? cancellable = null) throws Error, IOError {
 			return yield find_process ((process) => { return process.pid == pid; }, options, cancellable);
@@ -754,6 +1002,13 @@ namespace Frida {
 			return find_process_sync ((process) => { return process.pid == pid; }, options, cancellable);
 		}
 
+		/**
+		 * Finds a process whose name matches.
+		 *
+		 * @param name the process name to match
+		 * @param options matching options, or null
+		 * @return the matching process, or null if not found
+		 */
 		public async Process? find_process_by_name (string name, ProcessMatchOptions? options = null,
 				Cancellable? cancellable = null) throws Error, IOError {
 			var folded_name = name.casefold ();
@@ -766,6 +1021,13 @@ namespace Frida {
 			return find_process_sync ((process) => { return process.name.casefold () == folded_name; }, options, cancellable);
 		}
 
+		/**
+		 * Finds the first process accepted by @predicate.
+		 *
+		 * @param predicate function deciding whether a process matches
+		 * @param options matching options, or null
+		 * @return the matching process, or null if not found
+		 */
 		public async Process? find_process (ProcessPredicate predicate, ProcessMatchOptions? options = null,
 				Cancellable? cancellable = null) throws Error, IOError {
 			Process? process = null;
@@ -855,6 +1117,12 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Enumerates the processes running on the device.
+		 *
+		 * @param options query options to scope and shape the results, or null
+		 * @return the matching processes
+		 */
 		public async ProcessList enumerate_processes (ProcessQueryOptions? options = null,
 				Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
@@ -891,6 +1159,10 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Enables spawn gating, suspending every newly spawned process until it
+		 * is explicitly resumed.
+		 */
 		public async void enable_spawn_gating (Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
 
@@ -913,6 +1185,9 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Disables spawn gating.
+		 */
 		public async void disable_spawn_gating (Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
 
@@ -935,6 +1210,11 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Enumerates the spawns currently suspended by spawn gating.
+		 *
+		 * @return the pending spawns
+		 */
 		public async SpawnList enumerate_pending_spawn (Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
 
@@ -963,6 +1243,11 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Enumerates the children currently suspended by child gating.
+		 *
+		 * @return the pending children
+		 */
 		public async ChildList enumerate_pending_children (Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
 
@@ -991,6 +1276,14 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Starts a new process in a suspended state, ready to be resumed once
+		 * instrumentation is in place.
+		 *
+		 * @param program path or identifier of the program to launch
+		 * @param options spawn options such as argv, env, and stdio, or null
+		 * @return the PID of the newly created process
+		 */
 		public async uint spawn (string program, SpawnOptions? options = null, Cancellable? cancellable = null)
 				throws Error, IOError {
 			check_open ();
@@ -1053,6 +1346,12 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Writes data to the standard input of a spawned process.
+		 *
+		 * @param pid the process ID
+		 * @param data the bytes to write
+		 */
 		public async void input (uint pid, Bytes data, Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
 
@@ -1081,6 +1380,12 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Resumes a process that was spawned in a suspended state, or
+		 * suspended via spawn gating.
+		 *
+		 * @param pid the process ID to resume
+		 */
 		public async void resume (uint pid, Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
 
@@ -1107,6 +1412,11 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Terminates a process.
+		 *
+		 * @param pid the process ID to kill
+		 */
 		public async void kill (uint pid, Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
 
@@ -1135,6 +1445,15 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Attaches to a process, giving a {@link Session} through which scripts
+		 * can be created and run inside it.
+		 *
+		 * @param pid the process ID to attach to
+		 * @param options session options, such as the realm or persistence
+		 *   timeout, or null
+		 * @return the new session
+		 */
 		public async Session attach (uint pid, SessionOptions? options = null,
 				Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
@@ -1196,6 +1515,15 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Injects a shared library from a file into a process.
+		 *
+		 * @param pid the process ID to inject into
+		 * @param path path to the library on the device
+		 * @param entrypoint name of the entrypoint function to call
+		 * @param data a string passed to the entrypoint
+		 * @return an injection ID, later matched by {@link Device.uninjected}
+		 */
 		public async uint inject_library_file (uint pid, string path, string entrypoint, string data,
 				Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
@@ -1232,6 +1560,15 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Injects a shared library from an in-memory blob into a process.
+		 *
+		 * @param pid the process ID to inject into
+		 * @param blob the library image
+		 * @param entrypoint name of the entrypoint function to call
+		 * @param data a string passed to the entrypoint
+		 * @return an injection ID, later matched by {@link Device.uninjected}
+		 */
 		public async uint inject_library_blob (uint pid, Bytes blob, string entrypoint, string data,
 				Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
@@ -1268,6 +1605,12 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Opens a raw communication channel to the given address on the device.
+		 *
+		 * @param address the address to connect to
+		 * @return a stream for reading from and writing to the channel
+		 */
 		public async IOStream open_channel (string address, Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
 
@@ -1297,6 +1640,12 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Opens a service identified by the given address.
+		 *
+		 * @param address the service address
+		 * @return the opened service
+		 */
 		public async Service open_service (string address, Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
 
@@ -1328,6 +1677,9 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Removes any persistent pairing record this host has with the device.
+		 */
 		public async void unpair (Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
 
@@ -1573,9 +1925,21 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * The kind of a {@link Device}.
+	 */
 	public enum DeviceType {
+		/**
+		 * The local system.
+		 */
 		LOCAL,
+		/**
+		 * A device reached over the network.
+		 */
 		REMOTE,
+		/**
+		 * A USB-connected device.
+		 */
 		USB;
 
 		public static DeviceType from_nick (string nick) throws Error {
@@ -1587,22 +1951,38 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * Options for connecting to a remote device with
+	 * {@link DeviceManager.add_remote_device}.
+	 */
 	public sealed class RemoteDeviceOptions : Object {
+		/**
+		 * TLS certificate to present, for connections that require one.
+		 */
 		public TlsCertificate? certificate {
 			get;
 			set;
 		}
 
+		/**
+		 * Origin to send when connecting, if the server checks it.
+		 */
 		public string? origin {
 			get;
 			set;
 		}
 
+		/**
+		 * Authentication token to present to the server.
+		 */
 		public string? token {
 			get;
 			set;
 		}
 
+		/**
+		 * Interval between keepalive messages, in seconds, or -1 to disable.
+		 */
 		public int keepalive_interval {
 			get;
 			set;
@@ -1610,6 +1990,9 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * An immutable list of {@link Application} objects.
+	 */
 	public sealed class ApplicationList : Object {
 		private Gee.List<Application> items;
 
@@ -1617,31 +2000,57 @@ namespace Frida {
 			this.items = items;
 		}
 
+		/**
+		 * Gets the number of applications in the list.
+		 *
+		 * @return the count
+		 */
 		public int size () {
 			return items.size;
 		}
 
+		/**
+		 * Gets the application at the given position.
+		 *
+		 * @param index zero-based position
+		 * @return the application
+		 */
 		public new Application get (int index) {
 			return items.get (index);
 		}
 	}
 
+	/**
+	 * Represents an application installed on a device.
+	 */
 	public sealed class Application : Object {
+		/**
+		 * The application's identifier, such as its bundle or package ID.
+		 */
 		public string identifier {
 			get;
 			construct;
 		}
 
+		/**
+		 * The application's display name.
+		 */
 		public string name {
 			get;
 			construct;
 		}
 
+		/**
+		 * The PID of the application if it is running, or 0 otherwise.
+		 */
 		public uint pid {
 			get;
 			construct;
 		}
 
+		/**
+		 * Additional parameters describing the application, keyed by name.
+		 */
 		public HashTable<string, Variant> parameters {
 			get;
 			construct;
@@ -1652,6 +2061,9 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * An immutable list of {@link Process} objects.
+	 */
 	public sealed class ProcessList : Object {
 		private Gee.List<Process> items;
 
@@ -1659,26 +2071,49 @@ namespace Frida {
 			this.items = items;
 		}
 
+		/**
+		 * Gets the number of processes in the list.
+		 *
+		 * @return the count
+		 */
 		public int size () {
 			return items.size;
 		}
 
+		/**
+		 * Gets the process at the given position.
+		 *
+		 * @param index zero-based position
+		 * @return the process
+		 */
 		public new Process get (int index) {
 			return items.get (index);
 		}
 	}
 
+	/**
+	 * Represents a process running on a device.
+	 */
 	public sealed class Process : Object {
+		/**
+		 * The process ID.
+		 */
 		public uint pid {
 			get;
 			construct;
 		}
 
+		/**
+		 * The process name.
+		 */
 		public string name {
 			get;
 			construct;
 		}
 
+		/**
+		 * Additional parameters describing the process, keyed by name.
+		 */
 		public HashTable<string, Variant> parameters {
 			get;
 			construct;
@@ -1689,13 +2124,22 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * Options for scoping and shaping a process query or match.
+	 */
 	public sealed class ProcessMatchOptions : Object {
+		/**
+		 * How long to wait for a match, in milliseconds, or 0 to not wait.
+		 */
 		public int timeout {
 			get;
 			set;
 			default = 0;
 		}
 
+		/**
+		 * How much detail to include about each process.
+		 */
 		public Scope scope {
 			get;
 			set;
@@ -1703,33 +2147,55 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * Options controlling how a process is spawned with {@link Device.spawn}.
+	 */
 	public sealed class SpawnOptions : Object {
+		/**
+		 * The argument vector, replacing the default. The first element is
+		 * conventionally the program itself.
+		 */
 		public string[]? argv {
 			get;
 			set;
 		}
 
+		/**
+		 * The complete environment, replacing the default.
+		 */
 		public string[]? envp {
 			get;
 			set;
 		}
 
+		/**
+		 * Environment entries to add to or override in the default environment.
+		 */
 		public string[]? env {
 			get;
 			set;
 		}
 
+		/**
+		 * The working directory to start in.
+		 */
 		public string? cwd {
 			get;
 			set;
 		}
 
+		/**
+		 * How to set up the standard I/O streams of the new process.
+		 */
 		public Stdio stdio {
 			get;
 			set;
 			default = INHERIT;
 		}
 
+		/**
+		 * Auxiliary, platform-specific spawn parameters, keyed by name.
+		 */
 		public HashTable<string, Variant> aux {
 			get;
 			set;
@@ -1737,6 +2203,9 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * An immutable list of {@link Spawn} objects.
+	 */
 	public sealed class SpawnList : Object {
 		private Gee.List<Spawn> items;
 
@@ -1744,21 +2213,41 @@ namespace Frida {
 			this.items = items;
 		}
 
+		/**
+		 * Gets the number of spawns in the list.
+		 *
+		 * @return the count
+		 */
 		public int size () {
 			return items.size;
 		}
 
+		/**
+		 * Gets the spawn at the given position.
+		 *
+		 * @param index zero-based position
+		 * @return the spawn
+		 */
 		public new Spawn get (int index) {
 			return items.get (index);
 		}
 	}
 
+	/**
+	 * Represents a process spawned and held suspended by spawn gating.
+	 */
 	public sealed class Spawn : Object {
+		/**
+		 * The process ID of the spawned process.
+		 */
 		public uint pid {
 			get;
 			construct;
 		}
 
+		/**
+		 * The identifier of the program that was spawned, if known.
+		 */
 		public string? identifier {
 			get;
 			construct;
@@ -1777,6 +2266,9 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * An immutable list of {@link Child} objects.
+	 */
 	public sealed class ChildList : Object {
 		private Gee.List<Child> items;
 
@@ -1784,46 +2276,81 @@ namespace Frida {
 			this.items = items;
 		}
 
+		/**
+		 * Gets the number of children in the list.
+		 *
+		 * @return the count
+		 */
 		public int size () {
 			return items.size;
 		}
 
+		/**
+		 * Gets the child at the given position.
+		 *
+		 * @param index zero-based position
+		 * @return the child
+		 */
 		public new Child get (int index) {
 			return items.get (index);
 		}
 	}
 
+	/**
+	 * Represents a child process observed while child gating is enabled.
+	 */
 	public sealed class Child : Object {
+		/**
+		 * The child's process ID.
+		 */
 		public uint pid {
 			get;
 			construct;
 		}
 
+		/**
+		 * The process ID of the parent.
+		 */
 		public uint parent_pid {
 			get;
 			construct;
 		}
 
+		/**
+		 * How the child came to be, such as fork or exec.
+		 */
 		public ChildOrigin origin {
 			get;
 			construct;
 		}
 
+		/**
+		 * The identifier of the program, if known.
+		 */
 		public string? identifier {
 			get;
 			construct;
 		}
 
+		/**
+		 * The path of the program image, if known.
+		 */
 		public string? path {
 			get;
 			construct;
 		}
 
+		/**
+		 * The argument vector the child was launched with, if known.
+		 */
 		public string[]? argv {
 			get;
 			construct;
 		}
 
+		/**
+		 * The environment the child was launched with, if known.
+		 */
 		public string[]? envp {
 			get;
 			construct;
@@ -1857,27 +2384,45 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * Details of a process crash.
+	 */
 	public sealed class Crash : Object {
+		/**
+		 * The process ID that crashed.
+		 */
 		public uint pid {
 			get;
 			construct;
 		}
 
+		/**
+		 * The name of the process that crashed.
+		 */
 		public string process_name {
 			get;
 			construct;
 		}
 
+		/**
+		 * A short, human-readable summary of the crash.
+		 */
 		public string summary {
 			get;
 			construct;
 		}
 
+		/**
+		 * The full crash report.
+		 */
 		public string report {
 			get;
 			construct;
 		}
 
+		/**
+		 * Additional parameters describing the crash, keyed by name.
+		 */
 		public HashTable<string, Variant> parameters {
 			get;
 			construct;
@@ -1906,8 +2451,21 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * A message bus for exchanging messages with a {@link Device}, obtained via
+	 * {@link Device.bus}.
+	 */
 	public sealed class Bus : Object {
+		/**
+		 * Emitted when the bus is detached from the device.
+		 */
 		public signal void detached ();
+		/**
+		 * Emitted when a message is received from the device.
+		 *
+		 * @param json the message as a JSON string
+		 * @param data binary data accompanying the message, if any
+		 */
 		public signal void message (string json, Bytes? data);
 
 		private weak Device device;
@@ -1921,10 +2479,19 @@ namespace Frida {
 			this.device = device;
 		}
 
+		/**
+		 * Checks whether the bus is currently detached.
+		 *
+		 * @return true if not attached
+		 */
 		public bool is_detached () {
 			return attach_request == null;
 		}
 
+		/**
+		 * Attaches to the device's message bus, after which messages can be
+		 * posted and received.
+		 */
 		public async void attach (Cancellable? cancellable = null) throws Error, IOError {
 			while (attach_request != null) {
 				try {
@@ -2000,6 +2567,12 @@ namespace Frida {
 			detached ();
 		}
 
+		/**
+		 * Posts a message to the bus.
+		 *
+		 * @param json the message as a JSON string
+		 * @param data binary data to accompany the message, if any
+		 */
 		public void post (string json, Bytes? data = null) {
 			MainContext context = get_main_context ();
 			if (context.is_owner ()) {
@@ -2038,8 +2611,20 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * A connection to a device-specific service, opened via
+	 * {@link Device.open_service}.
+	 */
 	public sealed class Service : Object {
+		/**
+		 * Emitted when the service connection is closed.
+		 */
 		public signal void close ();
+		/**
+		 * Emitted when the service sends a message.
+		 *
+		 * @param message the message
+		 */
 		public signal void message (Variant message);
 
 		private ServiceSession? session;
@@ -2090,10 +2675,19 @@ namespace Frida {
 			session = null;
 		}
 
+		/**
+		 * Checks whether the service connection has been closed.
+		 *
+		 * @return true if closed
+		 */
 		public bool is_closed () {
 			return session == null;
 		}
 
+		/**
+		 * Activates the service, completing any handshake needed before
+		 * requests can be made.
+		 */
 		public async void activate (Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
 
@@ -2114,6 +2708,9 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Cancels the service connection, closing it.
+		 */
 		public async void cancel (Cancellable? cancellable = null) throws IOError {
 			if (session == null)
 				return;
@@ -2140,6 +2737,12 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Sends a request to the service and waits for its response.
+		 *
+		 * @param parameters the request parameters
+		 * @return the service's response
+		 */
 		public async Variant request (Variant parameters, Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
 
@@ -2190,14 +2793,31 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * A live connection to a process, obtained via {@link Device.attach},
+	 * through which scripts can be created and run.
+	 */
 	public sealed class Session : Object, AgentMessageSink {
+		/**
+		 * Emitted when the session is detached from the target process.
+		 *
+		 * @param reason why the session was detached
+		 * @param crash the crash that caused the detach, if any
+		 */
 		public signal void detached (SessionDetachReason reason, Crash? crash);
 
+		/**
+		 * The PID of the attached process.
+		 */
 		public uint pid {
 			get;
 			construct;
 		}
 
+		/**
+		 * How long the session may survive a temporary disconnection before
+		 * being torn down, in seconds; 0 means no persistence.
+		 */
 		public uint persist_timeout {
 			get;
 			construct;
@@ -2248,10 +2868,19 @@ namespace Frida {
 			this.device = device;
 		}
 
+		/**
+		 * Checks whether the session has been detached from the target.
+		 *
+		 * @return true if no longer attached
+		 */
 		public bool is_detached () {
 			return state != ATTACHED;
 		}
 
+		/**
+		 * Detaches from the target process, tearing down all scripts created
+		 * through this session.
+		 */
 		public async void detach (Cancellable? cancellable = null) throws IOError {
 			yield _do_close (APPLICATION_REQUESTED, CrashInfo.empty (), true, cancellable);
 		}
@@ -2270,6 +2899,10 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Resumes a session that was persisted across a disconnection,
+		 * reattaching to the target.
+		 */
 		public async void resume (Cancellable? cancellable = null) throws Error, IOError {
 			switch (state) {
 				case ATTACHED:
@@ -2329,6 +2962,10 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Enables child gating, so that children of the target process are held
+		 * suspended until explicitly resumed.
+		 */
 		public async void enable_child_gating (Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
 
@@ -2349,6 +2986,9 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Disables child gating.
+		 */
 		public async void disable_child_gating (Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
 
@@ -2369,6 +3009,13 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Creates a new script from JavaScript source.
+		 *
+		 * @param source the script's JavaScript source code
+		 * @param options script options such as name and runtime, or null
+		 * @return the new script, not yet loaded
+		 */
 		public async Script create_script (string source, ScriptOptions? options = null, Cancellable? cancellable = null)
 				throws Error, IOError {
 			check_open ();
@@ -2407,6 +3054,14 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Creates a new script from a precompiled bytecode blob, as produced by
+		 * {@link Session.compile_script}.
+		 *
+		 * @param bytes the compiled script
+		 * @param options script options such as name and runtime, or null
+		 * @return the new script, not yet loaded
+		 */
 		public async Script create_script_from_bytes (Bytes bytes, ScriptOptions? options = null, Cancellable? cancellable = null)
 				throws Error, IOError {
 			check_open ();
@@ -2446,6 +3101,14 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Compiles JavaScript source to a bytecode blob, which can later be
+		 * loaded with {@link Session.create_script_from_bytes}.
+		 *
+		 * @param source the script's JavaScript source code
+		 * @param options script options affecting compilation, or null
+		 * @return the compiled bytecode
+		 */
 		public async Bytes compile_script (string source, ScriptOptions? options = null, Cancellable? cancellable = null)
 				throws Error, IOError {
 			check_open ();
@@ -2479,6 +3142,14 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Builds a heap snapshot by running the given script, so that scripts
+		 * created later can start from the captured state.
+		 *
+		 * @param embed_script JavaScript to run to set up the snapshot
+		 * @param options snapshot options, or null
+		 * @return the serialized snapshot
+		 */
 		public async Bytes snapshot_script (string embed_script, SnapshotOptions? options = null, Cancellable? cancellable = null)
 				throws Error, IOError {
 			check_open ();
@@ -2512,6 +3183,13 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Sets up a peer-to-peer connection to the target, so that subsequent
+		 * traffic flows directly rather than through the device's host session.
+		 *
+		 * @param options peer connection options, such as STUN and relays, or
+		 *   null
+		 */
 		public async void setup_peer_connection (PeerOptions? options = null,
 				Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
@@ -2883,6 +3561,13 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Joins a portal, making the target reachable through it.
+		 *
+		 * @param address the portal address to connect to
+		 * @param options portal options, such as a token or ACL, or null
+		 * @return a membership handle that can later leave the portal
+		 */
 		public async PortalMembership join_portal (string address, PortalOptions? options = null, Cancellable? cancellable = null)
 				throws Error, IOError {
 			check_open ();
@@ -3158,8 +3843,21 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * A piece of JavaScript loaded into the target process, created through a
+	 * {@link Session}.
+	 */
 	public sealed class Script : Object {
+		/**
+		 * Emitted when the script has been unloaded and is no longer usable.
+		 */
 		public signal void destroyed ();
+		/**
+		 * Emitted when the script sends a message to the host.
+		 *
+		 * @param json the message as a JSON string
+		 * @param data binary data accompanying the message, if any
+		 */
 		public signal void message (string json, Bytes? data);
 
 		private AgentScriptId id;
@@ -3176,10 +3874,18 @@ namespace Frida {
 			this.session = session;
 		}
 
+		/**
+		 * Checks whether the script has been unloaded.
+		 *
+		 * @return true if the script is no longer loaded
+		 */
 		public bool is_destroyed () {
 			return close_request != null;
 		}
 
+		/**
+		 * Loads and starts running the script in the target process.
+		 */
 		public async void load (Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
 
@@ -3200,6 +3906,9 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Unloads the script from the target process.
+		 */
 		public async void unload (Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
 
@@ -3216,6 +3925,10 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Eternalizes the script so it keeps running after the session is
+		 * detached, instead of being unloaded.
+		 */
 		public async void eternalize (Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
 
@@ -3238,6 +3951,12 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Posts a message to the script, delivered to its `recv` handlers.
+		 *
+		 * @param json the message as a JSON string
+		 * @param data binary data to accompany the message, if any
+		 */
 		public void post (string json, Bytes? data = null) {
 			MainContext context = get_main_context ();
 			if (context.is_owner ()) {
@@ -3259,6 +3978,12 @@ namespace Frida {
 			session._post_to_agent (AgentMessageKind.SCRIPT, id, json, data);
 		}
 
+		/**
+		 * Enables the JavaScript debugger for this script, listening for an
+		 * inspector client.
+		 *
+		 * @param port the TCP port to listen on, or 0 for the default
+		 */
 		public async void enable_debugger (uint16 port = 0, Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
 
@@ -3308,6 +4033,9 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Disables the JavaScript debugger for this script.
+		 */
 		public async void disable_debugger (Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
 
@@ -3395,6 +4123,9 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * A handle to a portal a session has joined via {@link Session.join_portal}.
+	 */
 	public sealed class PortalMembership : Object {
 		private uint id;
 		private Session session;
@@ -3406,6 +4137,9 @@ namespace Frida {
 			this.session = session;
 		}
 
+		/**
+		 * Leaves the portal, ending this membership.
+		 */
 		public async void terminate (Cancellable? cancellable = null) throws Error, IOError {
 			try {
 				yield session.active_session.leave_portal (PortalMembershipId (id), cancellable);
@@ -3436,9 +4170,24 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * Injects shared libraries into processes, the lower-level primitive
+	 * underlying agent injection.
+	 */
 	public interface Injector : Object {
+		/**
+		 * Emitted when an injected library has been unloaded.
+		 *
+		 * @param id the injection ID returned when the library was injected
+		 */
 		public signal void uninjected (uint id);
 
+		/**
+		 * Creates an injector backed by a helper process, suitable for
+		 * injecting into other processes.
+		 *
+		 * @return the new injector
+		 */
 		public static Injector new () {
 #if HAVE_LOCAL_BACKEND
 #if WINDOWS
@@ -3467,6 +4216,12 @@ namespace Frida {
 #endif
 		}
 
+		/**
+		 * Creates an in-process injector, for injecting into the current
+		 * process.
+		 *
+		 * @return the new injector
+		 */
 		public static Injector new_inprocess () {
 #if HAVE_LOCAL_BACKEND
 #if WINDOWS
@@ -3495,6 +4250,9 @@ namespace Frida {
 #endif
 		}
 
+		/**
+		 * Closes the injector, releasing its resources.
+		 */
 		public abstract async void close (Cancellable? cancellable = null) throws IOError;
 
 		public void close_sync (Cancellable? cancellable = null) throws IOError {
@@ -3511,6 +4269,15 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Injects a shared library from a file into a process.
+		 *
+		 * @param pid the process ID to inject into
+		 * @param path path to the library
+		 * @param entrypoint name of the entrypoint function to call
+		 * @param data a string passed to the entrypoint
+		 * @return an injection ID, later matched by {@link Injector.uninjected}
+		 */
 		public abstract async uint inject_library_file (uint pid, string path, string entrypoint, string data,
 			Cancellable? cancellable = null) throws Error, IOError;
 
@@ -3535,6 +4302,15 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Injects a shared library from an in-memory blob into a process.
+		 *
+		 * @param pid the process ID to inject into
+		 * @param blob the library image
+		 * @param entrypoint name of the entrypoint function to call
+		 * @param data a string passed to the entrypoint
+		 * @return an injection ID, later matched by {@link Injector.uninjected}
+		 */
 		public abstract async uint inject_library_blob (uint pid, Bytes blob, string entrypoint, string data,
 			Cancellable? cancellable = null) throws Error, IOError;
 
@@ -3559,6 +4335,12 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Stops monitoring an injected library, so its unload is no longer
+		 * tracked.
+		 *
+		 * @param id the injection ID
+		 */
 		public abstract async void demonitor (uint id, Cancellable? cancellable = null) throws Error, IOError;
 
 		public void demonitor_sync (uint id, Cancellable? cancellable = null) throws Error, IOError {
@@ -3575,6 +4357,13 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Stops monitoring an injection and clones its state into a new
+		 * injection that inherits it.
+		 *
+		 * @param id the injection ID
+		 * @return the new injection ID
+		 */
 		public abstract async uint demonitor_and_clone_state (uint id, Cancellable? cancellable = null) throws Error, IOError;
 
 		public uint demonitor_and_clone_state_sync (uint id, Cancellable? cancellable = null) throws Error, IOError {
@@ -3591,6 +4380,13 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Recreates the thread used by an injection in the target process, for
+		 * example after the process has forked.
+		 *
+		 * @param pid the process ID
+		 * @param id the injection ID
+		 */
 		public abstract async void recreate_thread (uint pid, uint id, Cancellable? cancellable = null) throws Error, IOError;
 
 		public void recreate_thread_sync (uint pid, uint id, Cancellable? cancellable = null) throws Error, IOError {

--- a/src/package-manager.vala
+++ b/src/package-manager.vala
@@ -1,7 +1,21 @@
 namespace Frida {
+	/**
+	 * Searches for and installs npm packages of Frida agents, for use with the
+	 * {@link Compiler}.
+	 */
 	public sealed class PackageManager : Object {
+		/**
+		 * Emitted as an install progresses.
+		 *
+		 * @param phase the current phase of the installation
+		 * @param fraction progress within the phase, from 0 to 1
+		 * @param details optional human-readable detail
+		 */
 		public signal void install_progress (PackageInstallPhase phase, double fraction, string? details = null);
 
+		/**
+		 * The npm registry host to use.
+		 */
 		public string registry {
 			get;
 			set;
@@ -10,6 +24,9 @@ namespace Frida {
 
 		private Soup.Session session;
 
+		/**
+		 * Creates a package manager.
+		 */
 		public PackageManager () {
 			string cache_dir = Path.build_filename (Environment.get_user_cache_dir (), "frida", "package-manager");
 			var cache = new Soup.Cache (cache_dir, Soup.CacheType.SINGLE_USER);
@@ -18,6 +35,13 @@ namespace Frida {
 			session.add_feature (cache);
 		}
 
+		/**
+		 * Searches the registry for packages matching a query.
+		 *
+		 * @param query the search query
+		 * @param options search options such as paging, or null
+		 * @return the matching packages
+		 */
 		public async PackageSearchResult search (string query, PackageSearchOptions? options = null,
 				Cancellable? cancellable = null) throws Error, IOError {
 			var opts = (options != null) ? options : new PackageSearchOptions ();
@@ -89,6 +113,14 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Installs packages into a project, emitting {@link
+		 * PackageManager.install_progress} as it goes.
+		 *
+		 * @param options install options, such as the project directory and the
+		 *   packages to install, or null
+		 * @return the result of the installation
+		 */
 		public async PackageInstallResult install (PackageInstallOptions? options = null, Cancellable? cancellable = null)
 				throws Error, IOError {
 			install_progress (INITIALIZING, 0.0);
@@ -2321,34 +2353,80 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * The phases an install passes through, reported via
+	 * {@link PackageManager.install_progress}.
+	 */
 	public enum PackageInstallPhase {
+		/**
+		 * Getting ready to install.
+		 */
 		INITIALIZING,
+		/**
+		 * Preparing the dependency set.
+		 */
 		PREPARING_DEPENDENCIES,
+		/**
+		 * Resolving a package to a concrete version.
+		 */
 		RESOLVING_PACKAGE,
+		/**
+		 * Fetching a resource.
+		 */
 		FETCHING_RESOURCE,
+		/**
+		 * The package was already installed.
+		 */
 		PACKAGE_ALREADY_INSTALLED,
+		/**
+		 * Downloading a package.
+		 */
 		DOWNLOADING_PACKAGE,
+		/**
+		 * A package was installed.
+		 */
 		PACKAGE_INSTALLED,
+		/**
+		 * Resolving and installing the full dependency set.
+		 */
 		RESOLVING_AND_INSTALLING_ALL,
+		/**
+		 * The installation is complete.
+		 */
 		COMPLETE,
 	}
 
+	/**
+	 * A package available in the registry.
+	 */
 	public sealed class Package : Object {
+		/**
+		 * The package name.
+		 */
 		public string name {
 			get;
 			construct;
 		}
 
+		/**
+		 * The package version.
+		 */
 		public string version {
 			get;
 			construct;
 		}
 
+		/**
+		 * A short description of the package, if any.
+		 */
 		public string? description {
 			get;
 			construct;
 		}
 
+		/**
+		 * A URL with more information about the package, if any.
+		 */
 		public string? url {
 			get;
 			construct;
@@ -2372,13 +2450,31 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * The role a package plays among a project's dependencies.
+	 */
 	public enum PackageRole {
+		/**
+		 * A regular runtime dependency.
+		 */
 		RUNTIME,
+		/**
+		 * A development-only dependency.
+		 */
 		DEVELOPMENT,
+		/**
+		 * An optional dependency.
+		 */
 		OPTIONAL,
+		/**
+		 * A peer dependency.
+		 */
 		PEER
 	}
 
+	/**
+	 * An immutable list of {@link Package} objects.
+	 */
 	public sealed class PackageList : Object {
 		private Gee.List<Package> items;
 
@@ -2386,22 +2482,42 @@ namespace Frida {
 			this.items = items;
 		}
 
+		/**
+		 * Gets the number of packages in the list.
+		 *
+		 * @return the count
+		 */
 		public int size () {
 			return items.size;
 		}
 
+		/**
+		 * Gets the package at the given position.
+		 *
+		 * @param index zero-based position
+		 * @return the package
+		 */
 		public new Package get (int index) {
 			return items.get (index);
 		}
 	}
 
+	/**
+	 * Options for {@link PackageManager.search}.
+	 */
 	public class PackageSearchOptions : Object {
+		/**
+		 * The number of results to skip, for paging.
+		 */
 		public uint offset {
 			get;
 			set;
 			default = 0;
 		}
 
+		/**
+		 * The maximum number of results to return.
+		 */
 		public uint limit {
 			get;
 			set;
@@ -2409,12 +2525,21 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * The result of a {@link PackageManager.search}.
+	 */
 	public sealed class PackageSearchResult : Object {
+		/**
+		 * The packages on this page of results.
+		 */
 		public PackageList packages {
 			get;
 			construct;
 		}
 
+		/**
+		 * The total number of matching packages, across all pages.
+		 */
 		public uint total {
 			get;
 			construct;
@@ -2425,39 +2550,71 @@ namespace Frida {
 		}
 	}
 
+	/**
+	 * Options for {@link PackageManager.install}.
+	 */
 	public class PackageInstallOptions : Object {
 		internal Gee.List<string> specs = new Gee.ArrayList<string> ();
 		internal Gee.Set<PackageRole> omits = new Gee.HashSet<PackageRole> ();
 
+		/**
+		 * The project directory to install into, or null for the current
+		 * directory.
+		 */
 		public string? project_root {
 			get;
 			set;
 		}
 
+		/**
+		 * The role to record the installed packages under.
+		 */
 		public PackageRole role {
 			get;
 			set;
 			default = RUNTIME;
 		}
 
+		/**
+		 * Removes all package specs to install.
+		 */
 		public void clear_specs () {
 			specs.clear ();
 		}
 
+		/**
+		 * Adds a package spec to install, such as `foo` or `foo@1.2.3`.
+		 *
+		 * @param spec the package spec
+		 */
 		public void add_spec (string spec) {
 			specs.add (spec);
 		}
 
+		/**
+		 * Removes all omitted roles.
+		 */
 		public void clear_omits () {
 			omits.clear ();
 		}
 
+		/**
+		 * Omits dependencies of the given role from the installation.
+		 *
+		 * @param role the role to omit
+		 */
 		public void add_omit (PackageRole role) {
 			omits.add (role);
 		}
 	}
 
+	/**
+	 * The result of a {@link PackageManager.install}.
+	 */
 	public sealed class PackageInstallResult : Object {
+		/**
+		 * The packages that were installed.
+		 */
 		public PackageList packages {
 			get;
 			construct;

--- a/src/portal-service.vala
+++ b/src/portal-service.vala
@@ -1,17 +1,80 @@
 namespace Frida {
+	/**
+	 * Hosts a Frida portal: a rendezvous point where instrumented processes
+	 * (nodes) and controllers meet, letting controllers reach nodes without a
+	 * direct connection to them.
+	 */
 	public sealed class PortalService : Object {
+		/**
+		 * Emitted when a node connects to the cluster endpoint.
+		 *
+		 * @param connection_id the connection's ID
+		 * @param remote_address the node's network address
+		 */
 		public signal void node_connected (uint connection_id, SocketAddress remote_address);
+		/**
+		 * Emitted when a node joins the portal, identifying its application.
+		 *
+		 * @param connection_id the connection's ID
+		 * @param application the node's application
+		 */
 		public signal void node_joined (uint connection_id, Application application);
+		/**
+		 * Emitted when a node leaves the portal.
+		 *
+		 * @param connection_id the connection's ID
+		 * @param application the node's application
+		 */
 		public signal void node_left (uint connection_id, Application application);
+		/**
+		 * Emitted when a node disconnects from the cluster endpoint.
+		 *
+		 * @param connection_id the connection's ID
+		 * @param remote_address the node's network address
+		 */
 		public signal void node_disconnected (uint connection_id, SocketAddress remote_address);
 
+		/**
+		 * Emitted when a controller connects to the control endpoint.
+		 *
+		 * @param connection_id the connection's ID
+		 * @param remote_address the controller's network address
+		 */
 		public signal void controller_connected (uint connection_id, SocketAddress remote_address);
+		/**
+		 * Emitted when a controller disconnects from the control endpoint.
+		 *
+		 * @param connection_id the connection's ID
+		 * @param remote_address the controller's network address
+		 */
 		public signal void controller_disconnected (uint connection_id, SocketAddress remote_address);
 
+		/**
+		 * Emitted when a connection successfully authenticates.
+		 *
+		 * @param connection_id the connection's ID
+		 * @param session_info JSON describing the authenticated session
+		 */
 		public signal void authenticated (uint connection_id, string session_info);
+		/**
+		 * Emitted when a controller subscribes to portal messages.
+		 *
+		 * @param connection_id the connection's ID
+		 */
 		public signal void subscribe (uint connection_id);
+		/**
+		 * Emitted when a message is received from a connection.
+		 *
+		 * @param connection_id the connection's ID
+		 * @param json the message as a JSON string
+		 * @param data binary data accompanying the message, if any
+		 */
 		public signal void message (uint connection_id, string json, Bytes? data);
 
+		/**
+		 * A device representing the portal itself, for interacting with the
+		 * connected nodes.
+		 */
 		public Device device {
 			get {
 				return _device;
@@ -19,11 +82,17 @@ namespace Frida {
 		}
 		private Device _device;
 
+		/**
+		 * The endpoint that nodes connect to.
+		 */
 		public EndpointParameters cluster_params {
 			get;
 			construct;
 		}
 
+		/**
+		 * The endpoint that controllers connect to, if any.
+		 */
 		public EndpointParameters? control_params {
 			get;
 			construct;
@@ -56,6 +125,13 @@ namespace Frida {
 			STARTED
 		}
 
+		/**
+		 * Creates a portal service.
+		 *
+		 * @param cluster_params the endpoint that nodes connect to
+		 * @param control_params the endpoint that controllers connect to, or
+		 *   null to disable the control endpoint
+		 */
 		public PortalService (EndpointParameters cluster_params, EndpointParameters? control_params = null) {
 			Object (cluster_params: cluster_params, control_params: control_params);
 		}
@@ -86,12 +162,22 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Adds another endpoint for nodes to connect to.
+		 *
+		 * @param endpoint_params the endpoint to add
+		 */
 		public void add_cluster_endpoint (EndpointParameters endpoint_params) throws Error {
 			if (state != STOPPED)
 				throw new Error.INVALID_OPERATION ("Cannot add endpoint after service has started");
 			cluster_services.add (make_cluster_service (endpoint_params));
 		}
 
+		/**
+		 * Adds another endpoint for controllers to connect to.
+		 *
+		 * @param endpoint_params the endpoint to add
+		 */
 		public void add_control_endpoint (EndpointParameters endpoint_params) throws Error {
 			if (state != STOPPED)
 				throw new Error.INVALID_OPERATION ("Cannot add endpoint after service has started");
@@ -110,6 +196,9 @@ namespace Frida {
 			return service;
 		}
 
+		/**
+		 * Starts the portal, binding its endpoints and accepting connections.
+		 */
 		public async void start (Cancellable? cancellable = null) throws Error, IOError {
 			if (state != STOPPED)
 				throw new Error.INVALID_OPERATION ("Invalid operation");
@@ -143,6 +232,9 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Stops the portal, disconnecting everyone and releasing its endpoints.
+		 */
 		public async void stop (Cancellable? cancellable = null) throws Error, IOError {
 			if (state != STARTED)
 				throw new Error.INVALID_OPERATION ("Invalid operation");
@@ -173,6 +265,11 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Disconnects a connection from the portal.
+		 *
+		 * @param connection_id the connection to disconnect
+		 */
 		public void kick (uint connection_id) {
 			MainContext context = get_main_context ();
 			if (context.is_owner ()) {
@@ -194,6 +291,13 @@ namespace Frida {
 			entry.connection.close.begin (io_cancellable);
 		}
 
+		/**
+		 * Posts a message to a single connection.
+		 *
+		 * @param connection_id the connection to send to
+		 * @param json the message as a JSON string
+		 * @param data binary data to accompany the message, if any
+		 */
 		public void post (uint connection_id, string json, Bytes? data = null) {
 			MainContext context = get_main_context ();
 			if (context.is_owner ()) {
@@ -214,6 +318,13 @@ namespace Frida {
 				entry.post (json, data);
 		}
 
+		/**
+		 * Posts a message to every connection bearing the given tag.
+		 *
+		 * @param tag the tag identifying the recipients
+		 * @param json the message as a JSON string
+		 * @param data binary data to accompany the message, if any
+		 */
 		public void narrowcast (string tag, string json, Bytes? data = null) {
 			MainContext context = get_main_context ();
 			if (context.is_owner ()) {
@@ -233,6 +344,12 @@ namespace Frida {
 				entry.post (json, data);
 		}
 
+		/**
+		 * Posts a message to every connection.
+		 *
+		 * @param json the message as a JSON string
+		 * @param data binary data to accompany the message, if any
+		 */
 		public void broadcast (string json, Bytes? data = null) {
 			MainContext context = get_main_context ();
 			if (context.is_owner ()) {
@@ -264,6 +381,12 @@ namespace Frida {
 			}
 		}
 
+		/**
+		 * Gets the tags currently applied to a connection.
+		 *
+		 * @param connection_id the connection to inspect
+		 * @return the connection's tags, or null if it has none
+		 */
 		public string[]? enumerate_tags (uint connection_id) {
 			MainContext context = get_main_context ();
 			if (context.is_owner ()) {
@@ -311,6 +434,13 @@ namespace Frida {
 			return strv;
 		}
 
+		/**
+		 * Applies a tag to a connection, so it can be reached with
+		 * {@link PortalService.narrowcast}.
+		 *
+		 * @param connection_id the connection to tag
+		 * @param tag the tag to apply
+		 */
 		public void tag (uint connection_id, string tag) {
 			MainContext context = get_main_context ();
 			if (context.is_owner ()) {
@@ -337,6 +467,12 @@ namespace Frida {
 			entry.tags.add (tag);
 		}
 
+		/**
+		 * Removes a tag from a connection.
+		 *
+		 * @param connection_id the connection to untag
+		 * @param tag the tag to remove
+		 */
 		public void untag (uint connection_id, string tag) {
 			MainContext context = get_main_context ();
 			if (context.is_owner ()) {


### PR DESCRIPTION
## Summary

Adds API reference documentation to frida-core's public surface, mirroring the effort in frida-gum. Docs are written as idiomatic **valadoc** comments in the `.vala` sources and flow into the generated `Frida-1.0.gir`, so they render through the same gi-docgen pipeline as frida-gum on the website.

## How it works

`valac --gir` strips doc comments, so this teaches `src/api/generate.py` — which already merges the core + base GIRs into `Frida-1.0.gir` — to pick the documentation up itself:

- Extracts `/** … */` blocks from the `.vala` sources (the top-level files plus `lib/base/**`), associating each with the declaration it precedes.
- Converts valadoc markup to the Markdown gi-docgen expects (`{{{ }}}` → fenced code, `''bold''`, `//italic//`, etc.).
- Resolves `{@link Foo.bar}` into real gi-docgen cross-references — `[class@Frida.Session]`, `[method@Frida.Device.attach]`, `[property@Frida.Device:id]`, `[signal@Frida.Device::output]`.
- Injects `<doc>` into the merged GIR, including per-`@param` and `@return` docs, with async `_sync`/`_finish` twins, property getter/setter methods, and Vala default constructors all handled.

No build-graph change — the docs live in the source and are emitted by the existing API-generation step.

## Coverage

**76/76 types** and **596/597 members** documented and verified in the generated GIR (the one exception is a `protected` internal helper). This spans the whole public API: `DeviceManager`/`Device`/`Session`/`Script`, spawn/attach/enumeration, the option and list types, errors and enums, the portal/control services, networking/auth, RPC, the `Compiler`, and the `PackageManager`.

## Commits

- `api: Inject Vala doc comments into the GIR` — the pipeline.
- `core: Document the public API` — `frida.vala`.
- `core: Document base enums and option types`.
- `core: Document portal, peer, and web types`.
- `core: Document compiler, packages, and services`.

## Notes

Verified end-to-end by running the modified `generate.py` against prebuilt core/base GIRs (no full frida-core build was done locally); the first CI build will confirm against freshly generated GIRs.
