### PR TITLE
Add argv to enumerated process parameters

### DIFF
--- a/src/darwin/system-darwin.m
+++ b/src/darwin/system-darwin.m
@@ -5,6 +5,7 @@
 #include <errno.h>
 #include <pwd.h>
 #include <signal.h>
+#include <string.h>
 #include <unistd.h>
 #include <sys/sysctl.h>
 
@@ -98,6 +99,7 @@ extern int proc_pidpath (int pid, void * buffer, uint32_t buffer_size);
 #endif
 
 static void frida_add_process_metadata (GHashTable * parameters, const struct kinfo_proc * process);
+static GVariant * frida_query_process_argv (guint pid);
 
 static struct kinfo_proc * frida_system_query_kinfo_procs (guint * count);
 static GVariant * frida_uid_to_name (uid_t uid);
@@ -615,6 +617,13 @@ frida_collect_process_info_from_kinfo (struct kinfo_proc * process, FridaEnumera
 
     if (scope != FRIDA_SCOPE_MINIMAL)
       g_hash_table_insert (info.parameters, g_strdup ("path"), g_variant_ref_sink (g_variant_new_string (path)));
+
+    if (scope == FRIDA_SCOPE_FULL)
+    {
+      GVariant * argv = frida_query_process_argv (info.pid);
+      if (argv != NULL)
+        g_hash_table_insert (info.parameters, g_strdup ("argv"), g_variant_ref_sink (argv));
+    }
   }
 
   if (still_alive)
@@ -820,6 +829,64 @@ frida_add_process_metadata (GHashTable * parameters, const struct kinfo_proc * p
   g_hash_table_insert (parameters, g_strdup ("started"), g_variant_ref_sink (g_variant_new_take_string (g_date_time_format_iso8601 (t1))));
   g_date_time_unref (t1);
   g_date_time_unref (t0);
+}
+
+static GVariant *
+frida_query_process_argv (guint pid)
+{
+  GVariant * result = NULL;
+  int argmax;
+  size_t argmax_size = sizeof (argmax);
+  int argmax_mib[] = { CTL_KERN, KERN_ARGMAX };
+  gchar * buffer = NULL;
+  size_t buffer_size;
+  int args_mib[] = { CTL_KERN, KERN_PROCARGS2, (int) pid };
+  int argc;
+  const gchar * cursor, * end;
+  GVariantBuilder builder;
+  int i;
+
+  if (sysctl (argmax_mib, G_N_ELEMENTS (argmax_mib), &argmax, &argmax_size, NULL, 0) != 0)
+    goto beach;
+
+  buffer = g_malloc (argmax);
+  buffer_size = argmax;
+
+  if (sysctl (args_mib, G_N_ELEMENTS (args_mib), buffer, &buffer_size, NULL, 0) != 0)
+    goto beach;
+
+  if (buffer_size < sizeof (int))
+    goto beach;
+
+  memcpy (&argc, buffer, sizeof (int));
+  if (argc <= 0)
+    goto beach;
+
+  cursor = buffer + sizeof (int);
+  end = buffer + buffer_size;
+
+  while (cursor != end && *cursor != '\0')
+    cursor++;
+  while (cursor != end && *cursor == '\0')
+    cursor++;
+
+  g_variant_builder_init (&builder, G_VARIANT_TYPE ("as"));
+
+  for (i = 0; i != argc && cursor != end; i++)
+  {
+    gsize arg_length = strnlen (cursor, end - cursor);
+    g_variant_builder_add_value (&builder, g_variant_new_take_string (g_strndup (cursor, arg_length)));
+    cursor += arg_length;
+    if (cursor != end)
+      cursor++;
+  }
+
+  result = g_variant_builder_end (&builder);
+
+beach:
+  g_free (buffer);
+
+  return result;
 }
 
 static struct kinfo_proc *

--- a/src/freebsd/system-freebsd.c
+++ b/src/freebsd/system-freebsd.c
@@ -3,6 +3,7 @@
 #include <errno.h>
 #include <pwd.h>
 #include <signal.h>
+#include <string.h>
 #include <sys/sysctl.h>
 #include <sys/types.h>
 #include <sys/user.h>
@@ -23,6 +24,7 @@ static void frida_add_process_metadata (GHashTable * parameters, const struct ki
 
 static struct kinfo_proc * frida_system_query_kinfo_procs (guint * count);
 static gboolean frida_system_query_proc_pathname (pid_t pid, gchar * path, gsize size);
+static GVariant * frida_query_process_argv (guint pid);
 static GVariant * frida_uid_to_name (uid_t uid);
 
 void
@@ -117,6 +119,13 @@ frida_collect_process_info_from_kinfo (struct kinfo_proc * process, FridaEnumera
 
     if (scope != FRIDA_SCOPE_MINIMAL)
       g_hash_table_insert (info.parameters, g_strdup ("path"), g_variant_ref_sink (g_variant_new_string (path)));
+
+    if (scope == FRIDA_SCOPE_FULL)
+    {
+      GVariant * argv = frida_query_process_argv (info.pid);
+      if (argv != NULL)
+        g_hash_table_insert (info.parameters, g_strdup ("argv"), g_variant_ref_sink (argv));
+    }
   }
 
   if (still_alive)
@@ -219,6 +228,50 @@ frida_system_query_proc_pathname (pid_t pid, gchar * path, gsize size)
     path[0] = '\0';
 
   return success;
+}
+
+static GVariant *
+frida_query_process_argv (guint pid)
+{
+  GVariant * result = NULL;
+  int mib[4];
+  gchar * buffer = NULL;
+  size_t size;
+  const gchar * cursor, * end;
+  GVariantBuilder builder;
+
+  mib[0] = CTL_KERN;
+  mib[1] = KERN_PROC;
+  mib[2] = KERN_PROC_ARGS;
+  mib[3] = pid;
+
+  size = 0;
+  if (sysctl (mib, G_N_ELEMENTS (mib), NULL, &size, NULL, 0) != 0 || size == 0)
+    goto beach;
+
+  buffer = g_malloc (size);
+  if (sysctl (mib, G_N_ELEMENTS (mib), buffer, &size, NULL, 0) != 0)
+    goto beach;
+
+  g_variant_builder_init (&builder, G_VARIANT_TYPE ("as"));
+
+  cursor = buffer;
+  end = buffer + size;
+  while (cursor != end)
+  {
+    gsize arg_length = strnlen (cursor, end - cursor);
+    g_variant_builder_add_value (&builder, g_variant_new_take_string (g_strndup (cursor, arg_length)));
+    cursor += arg_length;
+    if (cursor != end)
+      cursor++;
+  }
+
+  result = g_variant_builder_end (&builder);
+
+beach:
+  g_free (buffer);
+
+  return result;
 }
 
 static GVariant *

--- a/src/linux/system-linux.c
+++ b/src/linux/system-linux.c
@@ -15,6 +15,7 @@ struct _FridaEnumerateProcessesOperation
 };
 
 static void frida_collect_process_info (guint pid, FridaEnumerateProcessesOperation * op);
+static GVariant * frida_parse_cmdline_argv (const gchar * cmdline_data, gsize cmdline_length);
 static gboolean frida_is_directory_noexec (const gchar * directory);
 static gchar * frida_get_application_directory (void);
 static gboolean frida_add_process_metadata (GHashTable * parameters, const gchar * proc_entry_name);
@@ -86,6 +87,8 @@ frida_collect_process_info (guint pid, FridaEnumerateProcessesOperation * op)
   gchar * program_path = NULL;
   gchar * cmdline_path = NULL;
   gchar * cmdline_data = NULL;
+  gsize cmdline_length = 0;
+  GVariant * argv = NULL;
   gchar * name = NULL;
 
   proc_name = g_strdup_printf ("%u", pid);
@@ -100,9 +103,11 @@ frida_collect_process_info (guint pid, FridaEnumerateProcessesOperation * op)
 
   cmdline_path = g_build_filename ("/proc", proc_name, "cmdline", NULL);
 
-  g_file_get_contents (cmdline_path, &cmdline_data, NULL, NULL);
+  g_file_get_contents (cmdline_path, &cmdline_data, &cmdline_length, NULL);
   if (cmdline_data == NULL)
     goto beach;
+
+  argv = frida_parse_cmdline_argv (cmdline_data, cmdline_length);
 
   if (g_str_has_prefix (cmdline_data, "/proc/"))
   {
@@ -129,6 +134,11 @@ frida_collect_process_info (guint pid, FridaEnumerateProcessesOperation * op)
     g_hash_table_insert (info.parameters, g_strdup ("path"),
         g_variant_ref_sink (g_variant_new_take_string (g_steal_pointer (&program_path))));
 
+    if (op->scope == FRIDA_SCOPE_FULL && argv != NULL)
+    {
+      g_hash_table_insert (info.parameters, g_strdup ("argv"), g_variant_ref_sink (g_steal_pointer (&argv)));
+    }
+
     still_alive = frida_add_process_metadata (info.parameters, proc_name);
   }
 
@@ -138,12 +148,38 @@ frida_collect_process_info (guint pid, FridaEnumerateProcessesOperation * op)
     frida_host_process_info_destroy (&info);
 
 beach:
+  g_clear_pointer (&argv, g_variant_unref);
   g_free (name);
   g_free (cmdline_data);
   g_free (cmdline_path);
   g_free (program_path);
   g_free (exe_path);
   g_free (proc_name);
+}
+
+static GVariant *
+frida_parse_cmdline_argv (const gchar * cmdline_data, gsize cmdline_length)
+{
+  GVariantBuilder builder;
+  const gchar * cursor, * end;
+
+  if (cmdline_length == 0)
+    return NULL;
+
+  g_variant_builder_init (&builder, G_VARIANT_TYPE ("as"));
+
+  cursor = cmdline_data;
+  end = cmdline_data + cmdline_length;
+  while (cursor != end)
+  {
+    gsize arg_length = strnlen (cursor, end - cursor);
+    g_variant_builder_add_value (&builder, g_variant_new_take_string (g_strndup (cursor, arg_length)));
+    cursor += arg_length;
+    if (cursor != end)
+      cursor++;
+  }
+
+  return g_variant_builder_end (&builder);
 }
 
 void

--- a/src/windows/system-windows.c
+++ b/src/windows/system-windows.c
@@ -3,7 +3,9 @@
 #include "icon-helpers.h"
 
 #include <psapi.h>
+#include <shellapi.h>
 #include <tlhelp32.h>
+#include <winternl.h>
 
 #define DRIVE_STRINGS_MAX_LENGTH     (512)
 
@@ -22,6 +24,7 @@ static void frida_collect_process_info (guint pid, FridaEnumerateProcessesOperat
 static gboolean frida_add_process_metadata (GHashTable * parameters, guint pid, HANDLE process, FridaEnumerateProcessesOperation * op);
 
 static gboolean frida_get_process_filename (HANDLE process, WCHAR * name, DWORD name_capacity);
+static GVariant * frida_query_process_argv (guint pid);
 static GVariant * frida_get_process_user (HANDLE process);
 static GVariant * frida_get_process_start_time (HANDLE process);
 
@@ -128,8 +131,13 @@ frida_collect_process_info (guint pid, FridaEnumerateProcessesOperation * op)
 
   if (op->scope == FRIDA_SCOPE_FULL)
   {
+    GVariant * argv;
     GVariantBuilder builder;
     GVariant * small_icon, * large_icon;
+
+    argv = frida_query_process_argv (pid);
+    if (argv != NULL)
+      g_hash_table_insert (info.parameters, g_strdup ("argv"), g_variant_ref_sink (argv));
 
     g_variant_builder_init (&builder, G_VARIANT_TYPE ("aa{sv}"));
 
@@ -252,6 +260,61 @@ frida_get_process_filename (HANDLE process, WCHAR * name, DWORD name_capacity)
   }
 
   return FALSE;
+}
+
+static GVariant *
+frida_query_process_argv (guint pid)
+{
+  GVariant * result = NULL;
+  HANDLE process;
+  HMODULE ntdll;
+  NTSTATUS (NTAPI * query_information_process) (HANDLE, PROCESSINFOCLASS, PVOID, ULONG, PULONG);
+  PROCESS_BASIC_INFORMATION basic_info;
+  PEB peb;
+  RTL_USER_PROCESS_PARAMETERS parameters;
+  WCHAR * command_line = NULL;
+  WCHAR ** argv = NULL;
+  int argc, i;
+  GVariantBuilder builder;
+
+  process = OpenProcess (PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, pid);
+  if (process == NULL)
+    goto beach;
+
+  ntdll = GetModuleHandleW (L"ntdll.dll");
+  query_information_process = (gpointer) GetProcAddress (ntdll, "NtQueryInformationProcess");
+
+  if (query_information_process (process, ProcessBasicInformation, &basic_info, sizeof (basic_info), NULL) != 0)
+    goto beach;
+
+  if (!ReadProcessMemory (process, basic_info.PebBaseAddress, &peb, sizeof (peb), NULL))
+    goto beach;
+
+  if (!ReadProcessMemory (process, peb.ProcessParameters, &parameters, sizeof (parameters), NULL))
+    goto beach;
+
+  command_line = g_malloc (parameters.CommandLine.Length + sizeof (WCHAR));
+  if (!ReadProcessMemory (process, parameters.CommandLine.Buffer, command_line, parameters.CommandLine.Length, NULL))
+    goto beach;
+  command_line[parameters.CommandLine.Length / sizeof (WCHAR)] = L'\0';
+
+  argv = CommandLineToArgvW (command_line, &argc);
+  if (argv == NULL)
+    goto beach;
+
+  g_variant_builder_init (&builder, G_VARIANT_TYPE ("as"));
+  for (i = 0; i != argc; i++)
+    g_variant_builder_add_value (&builder, g_variant_new_take_string (g_utf16_to_utf8 (argv[i], -1, NULL, NULL, NULL)));
+  result = g_variant_builder_end (&builder);
+
+beach:
+  if (argv != NULL)
+    LocalFree (argv);
+  g_free (command_line);
+  if (process != NULL)
+    CloseHandle (process);
+
+  return result;
 }
 
 static GVariant *

--- a/tests/test-host-session.vala
+++ b/tests/test-host-session.vala
@@ -107,6 +107,13 @@ namespace Frida.HostSessionTest {
 #endif
 
 #if HAVE_LOCAL_BACKEND
+#if !QNX
+		GLib.Test.add_func ("/HostSession/process-argv-should-be-available", () => {
+			var h = new Harness ((h) => Local.process_argv_should_be_available.begin (h as Harness));
+			h.run ();
+		});
+#endif
+
 #if LINUX
 		GLib.Test.add_func ("/HostSession/Linux/backend", () => {
 			var h = new Harness ((h) => Linux.backend.begin (h as Harness));
@@ -1041,6 +1048,50 @@ namespace Frida.HostSessionTest {
 	}
 
 	namespace Local {
+
+#if !QNX
+		private static async void process_argv_should_be_available (Harness h) {
+			try {
+				var device_manager = new DeviceManager ();
+				var device = yield device_manager.get_device_by_type (DeviceType.LOCAL);
+
+				var target_path = Frida.Test.Labrats.path_to_executable ("sleeper");
+				var marker = "--frida-argv-probe";
+				var target = Frida.Test.Process.start (target_path, new string[] { marker });
+
+				var options = new ProcessQueryOptions ();
+				options.scope = FULL;
+				options.select_pid (target.id);
+
+				Process? match = null;
+				var timer = new Timer ();
+				while (match == null && timer.elapsed () < 5.0) {
+					var processes = yield device.enumerate_processes (options);
+					if (processes.size () > 0) {
+						match = processes.get (0);
+					} else {
+						Timeout.add (50, process_argv_should_be_available.callback);
+						yield;
+					}
+				}
+				assert_true (match != null);
+
+				var argv = match.parameters["argv"];
+				assert_true (argv != null);
+				assert_true (argv.n_children () == 2);
+				assert_true (argv.get_child_value (1).get_string () == marker);
+
+				target.kill ();
+
+				yield device_manager.close ();
+			} catch (GLib.Error e) {
+				printerr ("Oops: %s\n", e.message);
+				assert_not_reached ();
+			}
+
+			h.done ();
+		}
+#endif
 
 		private static async void latency_should_be_nominal (Harness h) {
 			h.disable_timeout ();


### PR DESCRIPTION
Populate an `argv` parameter, under full scope, with the target's command-line arguments, so process pickers can disambiguate same-named processes.

Sources per backend:

- Windows: the target PEB's `ProcessParameters.CommandLine`
- macOS: `KERN_PROCARGS2`
- Linux: `/proc/<pid>/cmdline`
- FreeBSD: `KERN_PROC_ARGS`

QNX has no documented per-process command line, so it is left out.

A new local test spawns a labrat with a known argument and verifies the round-trip, exercising the active backend on each CI platform.