### PR TITLE
android: tolerate transient USAP patch misses

### DIFF
--- a/src/linux/linux-host-session.vala
+++ b/src/linux/linux-host-session.vala
@@ -1598,8 +1598,19 @@ namespace Frida {
 
 				on_complete (null);
 			} catch (GLib.Error e) {
+				if (is_transient_usap_patch_failure (name, e)) {
+					on_complete (null);
+					return;
+				}
+
 				on_complete (e);
 			}
+		}
+
+		private static bool is_transient_usap_patch_failure (string process_name, GLib.Error error) {
+			return process_name.has_prefix ("usap") &&
+				error is Error.NOT_SUPPORTED &&
+				error.message == "Unable to locate android.os.Process.setArgV0() slot; please file a bug";
 		}
 
 		private async void inject_zymbiote (uint pid, Cancellable? cancellable) throws Error, IOError {


### PR DESCRIPTION
## Summary

Fix Android app spawning on devices where some transient `usap*`
processes do not have the ART boot image state needed for zymbiote
patching yet.

On Android 16, some `usap64` processes may only have
`libandroid_runtime.so` mapped and may not yet have the boot image /
`dalvik-LinearAlloc` mappings containing the
`android.os.Process.setArgV0()` JNI slot. Treating this as a fatal
error causes app spawning by package name to fail with:

`unable to locate android.os.Process.setArgV0() slot; please file a bug`

The main zygote and initialized USAPs can still be patched normally.
This change only tolerates this exact failure for `usap*` processes,
while preserving fatal behavior for `zygote*` and all other errors.

## Testing

Tested on Android 16 / SDK 36 / arm64.

Before the change, spawning `com.miui.notes` failed with:

`Failed to spawn: unable to locate android.os.Process.setArgV0() slot; please file a bug`

After the change:

```text
device: 25102RKBEC
spawned: 12360
resumed: 12360
Confirmed process state:
12360  1988 com.miui.notes         com.miui.notes
14288  1988 com.miui.notes:remote  com.miui.notes:remote
Also ran:
make
which rebuilt frida-server successfully.