### PR TITLE
Protect segments before applying fixups

### DIFF
--- a/src/fruity/injector.vala
+++ b/src/fruity/injector.vala
@@ -507,6 +507,19 @@ namespace Frida.Fruity.Injector {
 					yield output.write_all_async (bytes.get_data (), io_priority, cancellable, out bytes_written);
 				}
 
+				foreach (unowned Gum.DarwinSegment segment in module.segments.data) {
+					uint64 address = segment.vm_address + slide;
+
+					var protect_command = lldb.make_buffer_builder ()
+						.append_uint8 (UploadCommandType.PROTECT)
+						.append_uint64 (address)
+						.append_uint32 ((uint32) segment.vm_size)
+						.append_uint32 ((uint32) segment.protection)
+						.build ();
+					yield output.write_all_async (protect_command.get_data (), io_priority, cancellable,
+						out bytes_written);
+				}
+
 				if (!threaded_items.is_empty) {
 					var command = lldb.make_buffer_builder ()
 						.append_uint8 (UploadCommandType.APPLY_THREADED)
@@ -535,19 +548,6 @@ namespace Frida.Fruity.Injector {
 						.append_uint64 (module.preferred_address)
 						.build ();
 					yield output.write_all_async (fixup_command.get_data (), io_priority, cancellable,
-						out bytes_written);
-				}
-
-				foreach (unowned Gum.DarwinSegment segment in module.segments.data) {
-					uint64 address = segment.vm_address + slide;
-
-					var protect_command = lldb.make_buffer_builder ()
-						.append_uint8 (UploadCommandType.PROTECT)
-						.append_uint64 (address)
-						.append_uint32 ((uint32) segment.vm_size)
-						.append_uint32 ((uint32) segment.protection)
-						.build ();
-					yield output.write_all_async (protect_command.get_data (), io_priority, cancellable,
 						out bytes_written);
 				}
 


### PR DESCRIPTION
The upload injector maps the agent module r-x, streams in its segments, applies threaded and chained fixups, and only afterwards restores each segment's protection.

The fixup passes write the rebased and authenticated pointers directly into the module (e.g. into __DATA_CONST). Because the data segments are still mapped r-x at that point, on arm64e the first authenticated-rebase store faults with KERN_PROTECTION_FAILURE and the injection is aborted with "Invocation of 0x... crashed".

Apply each segment's protection before running the fixup passes, so the data segments are writable when the pointers land. __TEXT is not fixed up and stays r-x, so no rwx mapping is created, and the WRITE command keeps populating the module through its own temporary writable mapping regardless of ordering.