### PR TITLE
spawn-gating: Make it fail-safe and scoped

### DIFF
--- a/lib/base/session.vala
+++ b/lib/base/session.vala
@@ -12,6 +12,8 @@ namespace Frida {
 			Cancellable? cancellable) throws GLib.Error;
 
 		public abstract async void enable_spawn_gating (Cancellable? cancellable) throws GLib.Error;
+		public abstract async void enable_spawn_gating_with_options (HashTable<string, Variant> options,
+			Cancellable? cancellable) throws GLib.Error;
 		public abstract async void disable_spawn_gating (Cancellable? cancellable) throws GLib.Error;
 		public abstract async HostSpawnInfo[] enumerate_pending_spawn (Cancellable? cancellable) throws GLib.Error;
 		public abstract async HostChildInfo[] enumerate_pending_children (Cancellable? cancellable) throws GLib.Error;
@@ -31,6 +33,7 @@ namespace Frida {
 
 		public abstract async ServiceSessionId open_service (string address, Cancellable? cancellable) throws GLib.Error;
 
+		public signal void spawn_gating_disabled (SpawnGatingDisabledReason reason);
 		public signal void spawn_added (HostSpawnInfo info);
 		public signal void spawn_removed (HostSpawnInfo info);
 		public signal void child_added (HostChildInfo info);
@@ -903,6 +906,11 @@ namespace Frida {
 			throw_not_authorized ();
 		}
 
+		public async void enable_spawn_gating_with_options (HashTable<string, Variant> options,
+				Cancellable? cancellable) throws Error, IOError {
+			throw_not_authorized ();
+		}
+
 		public async void disable_spawn_gating (Cancellable? cancellable) throws Error, IOError {
 			throw_not_authorized ();
 		}
@@ -980,6 +988,46 @@ namespace Frida {
 	[NoReturn]
 	private void throw_not_authorized () throws Error {
 		throw new Error.PERMISSION_DENIED ("Not authorized, authentication required");
+	}
+
+	// Fires `expired` when a gated process goes unresumed too long, so the backend can cancel
+	// gating instead of letting a stalled client wedge process creation.
+	public sealed class SpawnGatingWatchdog : Object {
+		public signal void expired ();
+
+		public uint timeout_msec {
+			get;
+			construct;
+		}
+
+		private Gee.Map<uint, Source> deadlines = new Gee.HashMap<uint, Source> ();
+
+		// Default deadline: under the OS's own spawn-start timeouts (Android's is 10s).
+		public SpawnGatingWatchdog (uint timeout_msec = 8000) {
+			Object (timeout_msec: timeout_msec);
+		}
+
+		public void arm (uint pid) {
+			var deadline = new TimeoutSource (timeout_msec);
+			deadline.set_callback (() => {
+				expired ();
+				return Source.REMOVE;
+			});
+			deadline.attach (MainContext.get_thread_default ());
+			deadlines[pid] = deadline;
+		}
+
+		public void cancel (uint pid) {
+			Source? deadline;
+			if (deadlines.unset (pid, out deadline))
+				deadline.destroy ();
+		}
+
+		public void clear () {
+			foreach (var deadline in deadlines.values)
+				deadline.destroy ();
+			deadlines.clear ();
+		}
 	}
 
 	/**
@@ -1103,6 +1151,29 @@ namespace Frida {
 		public int fifo_fd;
 	}
 #endif
+
+	/**
+	 * Why spawn gating was disabled on a {@link Device}.
+	 */
+	public enum SpawnGatingDisabledReason {
+		/**
+		 * A client asked to disable spawn gating.
+		 */
+		APPLICATION_REQUESTED = 1,
+		/**
+		 * A caught process went unresumed long enough that the gater cancelled gating to
+		 * avoid stalling process creation.
+		 */
+		WATCHDOG_TIMEOUT;
+
+		public static SpawnGatingDisabledReason from_nick (string nick) throws Error {
+			return Marshal.enum_from_nick<SpawnGatingDisabledReason> (nick);
+		}
+
+		public string to_nick () {
+			return Marshal.enum_to_nick<SpawnGatingDisabledReason> (this);
+		}
+	}
 
 	/**
 	 * Why a {@link Session} was detached from its target.
@@ -1481,6 +1552,67 @@ namespace Frida {
 
 		public string to_nick () {
 			return Marshal.enum_to_nick<Scope> (this);
+		}
+	}
+
+	/**
+	 * Options for {@link Device.enable_spawn_gating}.
+	 */
+	public sealed class SpawnGatingOptions : Object {
+		/**
+		 * Which processes to gate. Anything other than DEFAULT requires a Frida new enough to
+		 * support scoping, and fails rather than silently gating something broader than asked.
+		 */
+		public SpawnGatingScope scope {
+			get;
+			set;
+			default = DEFAULT;
+		}
+
+		public HashTable<string, Variant> _serialize () {
+			var dict = make_parameters_dict ();
+
+			if (scope != DEFAULT)
+				dict["scope"] = new Variant.string (scope.to_nick ());
+
+			return dict;
+		}
+
+		public static SpawnGatingOptions _deserialize (HashTable<string, Variant> dict) throws Error {
+			var options = new SpawnGatingOptions ();
+
+			Variant? scope = dict["scope"];
+			if (scope != null) {
+				if (!scope.is_of_type (VariantType.STRING))
+					throw new Error.INVALID_ARGUMENT ("The 'scope' option must be a string");
+				options.scope = SpawnGatingScope.from_nick (scope.get_string ());
+			}
+
+			return options;
+		}
+	}
+
+	public enum SpawnGatingScope {
+		/**
+		 * Leave the choice to the implementation. Sent as a plain enable_spawn_gating call, so
+		 * it still works against a Frida too old to know about scopes.
+		 */
+		DEFAULT,
+		/**
+		 * Application launches only.
+		 */
+		APPLICATIONS,
+		/**
+		 * Every process created on the system. More potent but far more intrusive.
+		 */
+		PROCESSES;
+
+		public static SpawnGatingScope from_nick (string nick) throws Error {
+			return Marshal.enum_from_nick<SpawnGatingScope> (nick);
+		}
+
+		public string to_nick () {
+			return Marshal.enum_to_nick<SpawnGatingScope> (this);
 		}
 	}
 

--- a/lib/gadget/gadget.vala
+++ b/lib/gadget/gadget.vala
@@ -1810,6 +1810,11 @@ namespace Frida.Gadget {
 				throw new Error.NOT_SUPPORTED ("Not possible when embedded");
 			}
 
+			public async void enable_spawn_gating_with_options (HashTable<string, Variant> options,
+					Cancellable? cancellable) throws Error, IOError {
+				throw new Error.NOT_SUPPORTED ("Not possible when embedded");
+			}
+
 			public async void disable_spawn_gating (Cancellable? cancellable) throws Error, IOError {
 				throw new Error.NOT_SUPPORTED ("Not possible when embedded");
 			}

--- a/src/api/generate.py
+++ b/src/api/generate.py
@@ -661,6 +661,7 @@ def parse_api(frida_version, frida_version_components, api_version, toplevel_cod
     enum_types = []
 
     base_public_types = {
+        "SpawnGatingOptions": "ProcessMatchOptions",
         "FrontmostQueryOptions": "SpawnOptions",
         "ApplicationQueryOptions": "FrontmostQueryOptions",
         "ProcessQueryOptions": "ApplicationQueryOptions",

--- a/src/barebone/barebone-host-session.vala
+++ b/src/barebone/barebone-host-session.vala
@@ -286,6 +286,11 @@ namespace Frida {
 			throw_not_supported ();
 		}
 
+		public async void enable_spawn_gating_with_options (HashTable<string, Variant> options,
+				Cancellable? cancellable) throws Error, IOError {
+			throw_not_supported ();
+		}
+
 		public async void disable_spawn_gating (Cancellable? cancellable) throws Error, IOError {
 			throw_not_supported ();
 		}

--- a/src/control-service.vala
+++ b/src/control-service.vala
@@ -122,6 +122,7 @@ namespace Frida {
 
 		private void assign_session (HostSession session, HostSessionProvider provider) {
 			host_session = session;
+			host_session.spawn_gating_disabled.connect (on_spawn_gating_disabled);
 			host_session.spawn_added.connect (notify_spawn_added);
 			host_session.child_added.connect (notify_child_added);
 			host_session.child_removed.connect (notify_child_removed);
@@ -399,8 +400,9 @@ namespace Frida {
 				yield parent.teardown_control_channel (channel);
 			}
 
-			public async void enable_spawn_gating (ControlChannel requester) throws GLib.Error {
-				yield parent.enable_spawn_gating (requester);
+			public async void enable_spawn_gating (HashTable<string, Variant> options, ControlChannel requester)
+					throws GLib.Error {
+				yield parent.enable_spawn_gating (options, requester);
 			}
 
 			public async void disable_spawn_gating (ControlChannel requester) throws GLib.Error {
@@ -538,20 +540,27 @@ namespace Frida {
 			return channels.iterator ();
 		}
 
-		private async void enable_spawn_gating (ControlChannel requester) throws GLib.Error {
+		private async void enable_spawn_gating (HashTable<string, Variant> options, ControlChannel requester)
+				throws GLib.Error {
 			bool is_first = spawn_gaters.is_empty;
 			spawn_gaters.add (requester);
 			foreach (var spawn in pending_spawn.values)
 				spawn.pending_approvers.add (requester);
 
 			if (is_first)
-				yield host_session.enable_spawn_gating (io_cancellable);
+				yield host_session.enable_spawn_gating_with_options (options, io_cancellable);
 		}
 
 		private async void disable_spawn_gating (ControlChannel requester) throws GLib.Error {
 			if (spawn_gaters.remove (requester)) {
-				foreach (uint pid in pending_spawn.keys.to_array ())
-					host_session.resume.begin (pid, io_cancellable);
+				foreach (uint pid in pending_spawn.keys.to_array ()) {
+					PendingSpawn spawn = pending_spawn[pid];
+					var approvers = spawn.pending_approvers;
+					if (approvers.remove (requester) && approvers.is_empty) {
+						forget_pending_spawn (pid, spawn);
+						host_session.resume.begin (pid, io_cancellable);
+					}
+				}
 			}
 
 			if (spawn_gaters.is_empty)
@@ -576,11 +585,8 @@ namespace Frida {
 			var approvers = spawn.pending_approvers;
 			approvers.remove (requester);
 			if (approvers.is_empty) {
-				pending_spawn.unset (pid);
-
+				forget_pending_spawn (pid, spawn);
 				yield host_session.resume (pid, io_cancellable);
-
-				notify_spawn_removed (spawn.info);
 			}
 		}
 
@@ -687,9 +693,27 @@ namespace Frida {
 			return id;
 		}
 
+		// Backend disabled gating and already resumed everything; drop our mirror, tell the gaters.
+		private void on_spawn_gating_disabled (SpawnGatingDisabledReason reason) {
+			foreach (var spawn in pending_spawn.values.to_array ())
+				notify_spawn_removed (spawn.info);
+			pending_spawn.clear ();
+
+			foreach (ControlChannel channel in spawn_gaters)
+				channel.spawn_gating_disabled (reason);
+			spawn_gaters.clear ();
+		}
+
 		private void notify_spawn_added (HostSpawnInfo info) {
+			pending_spawn[info.pid] = new PendingSpawn (info.pid, info.identifier, spawn_gaters.iterator ());
+
 			foreach (ControlChannel channel in spawn_gaters)
 				channel.spawn_added (info);
+		}
+
+		private void forget_pending_spawn (uint pid, PendingSpawn spawn) {
+			pending_spawn.unset (pid);
+			notify_spawn_removed (spawn.info);
 		}
 
 		private void notify_spawn_removed (HostSpawnInfo info) {
@@ -926,7 +950,12 @@ namespace Frida {
 			}
 
 			public async void enable_spawn_gating (Cancellable? cancellable) throws GLib.Error {
-				yield parent.enable_spawn_gating (this);
+				yield parent.enable_spawn_gating (make_parameters_dict (), this);
+			}
+
+			public async void enable_spawn_gating_with_options (HashTable<string, Variant> options,
+					Cancellable? cancellable) throws GLib.Error {
+				yield parent.enable_spawn_gating (options, this);
 			}
 
 			public async void disable_spawn_gating (Cancellable? cancellable) throws GLib.Error {

--- a/src/darwin/darwin-host-session.vala
+++ b/src/darwin/darwin-host-session.vala
@@ -65,6 +65,7 @@ namespace Frida {
 
 		construct {
 			helper.output.connect (on_output);
+			helper.gating_cancelled.connect (on_spawn_gating_cancelled);
 			helper.spawn_added.connect (on_spawn_added);
 			helper.spawn_removed.connect (on_spawn_removed);
 
@@ -80,6 +81,7 @@ namespace Frida {
 
 #if IOS || TVOS
 			fruit_controller = new FruitController (this, io_cancellable);
+			fruit_controller.gating_cancelled.connect (on_spawn_gating_cancelled);
 			fruit_controller.spawn_added.connect (on_spawn_added);
 			fruit_controller.spawn_removed.connect (on_spawn_removed);
 			fruit_controller.process_crashed.connect (on_process_crashed);
@@ -91,6 +93,7 @@ namespace Frida {
 
 #if IOS || TVOS
 			yield fruit_controller.close (cancellable);
+			fruit_controller.gating_cancelled.disconnect (on_spawn_gating_cancelled);
 			fruit_controller.spawn_added.disconnect (on_spawn_added);
 			fruit_controller.spawn_removed.disconnect (on_spawn_removed);
 			fruit_controller.process_crashed.disconnect (on_process_crashed);
@@ -113,6 +116,7 @@ namespace Frida {
 
 			yield helper.close (cancellable);
 			helper.output.disconnect (on_output);
+			helper.gating_cancelled.disconnect (on_spawn_gating_cancelled);
 			helper.spawn_added.disconnect (on_spawn_added);
 			helper.spawn_removed.disconnect (on_spawn_removed);
 
@@ -182,11 +186,17 @@ namespace Frida {
 			return yield process_enumerator.enumerate_processes (ProcessQueryOptions._deserialize (options));
 		}
 
-		public override async void enable_spawn_gating (Cancellable? cancellable) throws Error, IOError {
+		public override async void enable_spawn_gating_with_options (HashTable<string, Variant> options,
+				Cancellable? cancellable) throws Error, IOError {
+			var scope = SpawnGatingOptions._deserialize (options).scope;
 #if IOS || TVOS
+			if (scope == PROCESSES)
+				throw new Error.NOT_SUPPORTED (
+					"Process-level gating is unavailable on this OS; use the 'applications' scope");
+
 			yield fruit_controller.enable_spawn_gating (cancellable);
 #else
-			yield helper.enable_spawn_gating (cancellable);
+			yield helper.enable_spawn_gating (scope, cancellable);
 #endif
 		}
 
@@ -196,6 +206,8 @@ namespace Frida {
 #else
 			yield helper.disable_spawn_gating (cancellable);
 #endif
+
+			spawn_gating_disabled (APPLICATION_REQUESTED);
 		}
 
 		public override async HostSpawnInfo[] enumerate_pending_spawn (Cancellable? cancellable) throws Error, IOError {
@@ -278,6 +290,10 @@ namespace Frida {
 			output (pid, fd, data);
 		}
 
+		private void on_spawn_gating_cancelled () {
+			spawn_gating_disabled (WATCHDOG_TIMEOUT);
+		}
+
 		private void on_spawn_added (HostSpawnInfo info) {
 			spawn_added (info);
 		}
@@ -353,6 +369,7 @@ namespace Frida {
 
 #if IOS || TVOS
 	private sealed class FruitController : Object, MappedAgentContainer {
+		public signal void gating_cancelled ();
 		public signal void spawn_added (HostSpawnInfo info);
 		public signal void spawn_removed (HostSpawnInfo info);
 		public signal void process_crashed (CrashInfo crash);
@@ -377,6 +394,7 @@ namespace Frida {
 		private bool spawn_gating_enabled = false;
 		private Gee.HashMap<string, Promise<uint>> spawn_requests = new Gee.HashMap<string, Promise<uint>> ();
 		private Gee.HashMap<uint, HostSpawnInfo?> pending_spawn = new Gee.HashMap<uint, HostSpawnInfo?> ();
+		private SpawnGatingWatchdog watchdog = new SpawnGatingWatchdog ();
 
 		private CrashReporterState crash_reporter_state;
 		private Gee.HashMap<uint, ReportCrashAgent> crash_agents = new Gee.HashMap<uint, ReportCrashAgent> ();
@@ -415,6 +433,8 @@ namespace Frida {
 
 			helper.process_resumed.connect (on_process_resumed);
 			helper.process_killed.connect (on_process_killed);
+
+			watchdog.expired.connect (on_watchdog_expired);
 		}
 
 		~FruitController () {
@@ -447,6 +467,8 @@ namespace Frida {
 
 		public async void disable_spawn_gating (Cancellable? cancellable) throws Error, IOError {
 			spawn_gating_enabled = false;
+
+			watchdog.clear ();
 
 			yield launchd_agent.disable_spawn_gating (cancellable);
 
@@ -512,6 +534,7 @@ namespace Frida {
 			HostSpawnInfo? info;
 			if (!pending_spawn.unset (pid, out info))
 				return false;
+			watchdog.cancel (pid);
 			spawn_removed (info);
 
 			yield helper.resume (pid, cancellable);
@@ -644,6 +667,11 @@ namespace Frida {
 			launchd_agent.claim_process.begin (pid, io_cancellable);
 		}
 
+		private void on_watchdog_expired () {
+			disable_spawn_gating.begin (io_cancellable);
+			gating_cancelled ();
+		}
+
 		private async void handle_spawn (HostSpawnInfo info) {
 			try {
 				var pid = info.pid;
@@ -662,6 +690,7 @@ namespace Frida {
 				}
 
 				pending_spawn[pid] = info;
+				watchdog.arm (pid);
 				spawn_added (info);
 			} catch (GLib.Error e) {
 			}

--- a/src/darwin/frida-helper-backend.vala
+++ b/src/darwin/frida-helper-backend.vala
@@ -49,6 +49,7 @@ namespace Frida {
 
 			dtrace_agent = DTraceAgent.try_open ();
 			if (dtrace_agent != null) {
+				dtrace_agent.gating_cancelled.connect (on_dtrace_agent_gating_cancelled);
 				dtrace_agent.spawn_added.connect (on_dtrace_agent_spawn_added);
 				dtrace_agent.spawn_removed.connect (on_dtrace_agent_spawn_removed);
 			}
@@ -97,6 +98,7 @@ namespace Frida {
 				yield;
 
 			if (dtrace_agent != null) {
+				dtrace_agent.gating_cancelled.disconnect (on_dtrace_agent_gating_cancelled);
 				dtrace_agent.spawn_added.disconnect (on_dtrace_agent_spawn_added);
 				dtrace_agent.spawn_removed.disconnect (on_dtrace_agent_spawn_removed);
 				yield dtrace_agent.close (cancellable);
@@ -107,8 +109,8 @@ namespace Frida {
 		public async void preload (Cancellable? cancellable) throws Error, IOError {
 		}
 
-		public async void enable_spawn_gating (Cancellable? cancellable) throws Error, IOError {
-			get_dtrace_agent ().enable_spawn_gating ();
+		public async void enable_spawn_gating (SpawnGatingScope scope, Cancellable? cancellable) throws Error, IOError {
+			get_dtrace_agent ().enable_spawn_gating (scope);
 		}
 
 		public async void disable_spawn_gating (Cancellable? cancellable) throws Error, IOError {
@@ -629,6 +631,10 @@ namespace Frida {
 			}
 		}
 
+		private void on_dtrace_agent_gating_cancelled () {
+			gating_cancelled ();
+		}
+
 		private void on_dtrace_agent_spawn_added (HostSpawnInfo info) {
 			spawn_added (info);
 		}
@@ -688,20 +694,36 @@ namespace Frida {
 	}
 
 	public sealed class DTraceAgent : Object {
+		public signal void gating_cancelled ();
 		public signal void spawn_added (HostSpawnInfo info);
 		public signal void spawn_removed (HostSpawnInfo info);
 
 		private Subprocess? dtrace;
 		private DataInputStream input;
+		private SpawnGatingScope scope;
 		private Gee.HashMap<uint, HostSpawnInfo?> pending_spawn = new Gee.HashMap<uint, HostSpawnInfo?> ();
+		private SpawnGatingWatchdog watchdog = new SpawnGatingWatchdog ();
 
 		private Cancellable io_cancellable = new Cancellable ();
+
+		// Present in every path inside an app bundle, so APPLICATIONS gates the whole app
+		// (helpers, XPC services, ...), not just its entry point.
+		private const string APP_BUNDLE_MARKER = ".app/";
 
 		public static DTraceAgent? try_open () {
 			if (Posix.getuid () != 0)
 				return null;
 
 			return new DTraceAgent ();
+		}
+
+		construct {
+			watchdog.expired.connect (on_watchdog_expired);
+		}
+
+		private void on_watchdog_expired () {
+			disable_spawn_gating.begin (io_cancellable);
+			gating_cancelled ();
 		}
 
 		public async void close (Cancellable? cancellable) throws IOError {
@@ -714,9 +736,11 @@ namespace Frida {
 			}
 		}
 
-		public void enable_spawn_gating () throws Error {
+		public void enable_spawn_gating (SpawnGatingScope scope) throws Error {
 			if (dtrace != null)
 				throw new Error.INVALID_OPERATION ("Already enabled");
+
+			this.scope = scope;
 
 			string? predicate = Environment.get_variable ("FRIDA_DTRACE_PREDICATE");
 			string predicate_clause;
@@ -776,6 +800,7 @@ namespace Frida {
 				spawn_removed (e.value);
 			}
 			pending_spawn.clear ();
+			watchdog.clear ();
 		}
 
 		public HostSpawnInfo[] enumerate_pending_spawn () {
@@ -788,8 +813,10 @@ namespace Frida {
 
 		public void on_resume (uint pid) {
 			HostSpawnInfo? info;
-			if (pending_spawn.unset (pid, out info))
+			if (pending_spawn.unset (pid, out info)) {
+				watchdog.cancel (pid);
 				spawn_removed (info);
+			}
 		}
 
 		private async void process_incoming_messages () {
@@ -837,8 +864,14 @@ namespace Frida {
 						continue;
 					}
 
+					if (scope != PROCESSES && !path.contains (APP_BUNDLE_MARKER)) {
+						DarwinHelperBackend.resume_without_validation (pid);
+						continue;
+					}
+
 					var info = HostSpawnInfo (pid, path);
 					pending_spawn[pid] = info;
+					watchdog.arm (pid);
 					spawn_added (info);
 				}
 			} catch (IOError e) {

--- a/src/darwin/frida-helper-null-backend.vala
+++ b/src/darwin/frida-helper-null-backend.vala
@@ -23,7 +23,7 @@ namespace Frida {
 		public async void preload (Cancellable? cancellable) throws Error, IOError {
 		}
 
-		public async void enable_spawn_gating (Cancellable? cancellable) throws Error, IOError {
+		public async void enable_spawn_gating (SpawnGatingScope scope, Cancellable? cancellable) throws Error, IOError {
 			throw_not_supported ();
 		}
 

--- a/src/darwin/frida-helper-process.vala
+++ b/src/darwin/frida-helper-process.vala
@@ -56,10 +56,10 @@ namespace Frida {
 			yield obtain (cancellable);
 		}
 
-		public async void enable_spawn_gating (Cancellable? cancellable) throws Error, IOError {
+		public async void enable_spawn_gating (SpawnGatingScope scope, Cancellable? cancellable) throws Error, IOError {
 			var helper = yield obtain (cancellable);
 			try {
-				yield helper.enable_spawn_gating (cancellable);
+				yield helper.enable_spawn_gating (scope, cancellable);
 			} catch (GLib.Error e) {
 				throw_helper_error (e);
 			}
@@ -420,6 +420,7 @@ namespace Frida {
 
 			proxy = pending_proxy;
 			proxy.output.connect (on_output);
+			proxy.gating_cancelled.connect (on_gating_cancelled);
 			proxy.spawn_added.connect (on_spawn_added);
 			proxy.spawn_removed.connect (on_spawn_removed);
 			proxy.injected.connect (on_injected);
@@ -439,6 +440,7 @@ namespace Frida {
 			obtain_request = null;
 
 			proxy.output.disconnect (on_output);
+			proxy.gating_cancelled.disconnect (on_gating_cancelled);
 			proxy.spawn_added.disconnect (on_spawn_added);
 			proxy.spawn_removed.disconnect (on_spawn_removed);
 			proxy.injected.disconnect (on_injected);
@@ -458,6 +460,10 @@ namespace Frida {
 
 		private void on_output (uint pid, int fd, uint8[] data) {
 			output (pid, fd, data);
+		}
+
+		private void on_gating_cancelled () {
+			gating_cancelled ();
 		}
 
 		private void on_spawn_added (HostSpawnInfo info) {

--- a/src/darwin/frida-helper-service.vala
+++ b/src/darwin/frida-helper-service.vala
@@ -44,6 +44,7 @@ namespace Frida {
 		construct {
 			backend.idle.connect (on_backend_idle);
 			backend.output.connect (on_backend_output);
+			backend.gating_cancelled.connect (on_backend_gating_cancelled);
 			backend.spawn_added.connect (on_backend_spawn_added);
 			backend.spawn_removed.connect (on_backend_spawn_removed);
 			backend.injected.connect (on_backend_injected);
@@ -93,6 +94,7 @@ namespace Frida {
 			}
 			backend.idle.disconnect (on_backend_idle);
 			backend.output.disconnect (on_backend_output);
+			backend.gating_cancelled.disconnect (on_backend_gating_cancelled);
 			backend.spawn_added.disconnect (on_backend_spawn_added);
 			backend.spawn_removed.disconnect (on_backend_spawn_removed);
 			backend.injected.disconnect (on_backend_injected);
@@ -147,8 +149,8 @@ namespace Frida {
 				shutdown.begin ();
 		}
 
-		public async void enable_spawn_gating (Cancellable? cancellable) throws Error, IOError {
-			yield backend.enable_spawn_gating (cancellable);
+		public async void enable_spawn_gating (SpawnGatingScope scope, Cancellable? cancellable) throws Error, IOError {
+			yield backend.enable_spawn_gating (scope, cancellable);
 		}
 
 		public async void disable_spawn_gating (Cancellable? cancellable) throws Error, IOError {
@@ -235,6 +237,10 @@ namespace Frida {
 
 		private void on_backend_output (uint pid, int fd, uint8[] data) {
 			output (pid, fd, data);
+		}
+
+		private void on_backend_gating_cancelled () {
+			gating_cancelled ();
 		}
 
 		private void on_backend_spawn_added (HostSpawnInfo info) {

--- a/src/darwin/frida-helper-types.vala
+++ b/src/darwin/frida-helper-types.vala
@@ -1,6 +1,7 @@
 namespace Frida {
 	public interface DarwinHelper : Object {
 		public signal void output (uint pid, int fd, uint8[] data);
+		public signal void gating_cancelled ();
 		public signal void spawn_added (HostSpawnInfo info);
 		public signal void spawn_removed (HostSpawnInfo info);
 		public signal void injected (uint id, uint pid, bool has_mapped_module, DarwinModuleDetails mapped_module);
@@ -16,7 +17,7 @@ namespace Frida {
 
 		public abstract async void preload (Cancellable? cancellable) throws Error, IOError;
 
-		public abstract async void enable_spawn_gating (Cancellable? cancellable) throws Error, IOError;
+		public abstract async void enable_spawn_gating (SpawnGatingScope scope, Cancellable? cancellable) throws Error, IOError;
 		public abstract async void disable_spawn_gating (Cancellable? cancellable) throws Error, IOError;
 		public abstract async HostSpawnInfo[] enumerate_pending_spawn (Cancellable? cancellable) throws Error, IOError;
 		public abstract async uint spawn (string path, HostSpawnOptions options, Cancellable? cancellable) throws Error, IOError;
@@ -49,6 +50,7 @@ namespace Frida {
 	[DBus (name = "re.frida.Helper")]
 	public interface DarwinRemoteHelper : Object {
 		public signal void output (uint pid, int fd, uint8[] data);
+		public signal void gating_cancelled ();
 		public signal void spawn_added (HostSpawnInfo info);
 		public signal void spawn_removed (HostSpawnInfo info);
 		public signal void injected (uint id, uint pid, bool has_mapped_module, DarwinModuleDetails mapped_module);
@@ -58,7 +60,7 @@ namespace Frida {
 
 		public abstract async void stop (Cancellable? cancellable) throws GLib.Error;
 
-		public abstract async void enable_spawn_gating (Cancellable? cancellable) throws GLib.Error;
+		public abstract async void enable_spawn_gating (SpawnGatingScope scope, Cancellable? cancellable) throws GLib.Error;
 		public abstract async void disable_spawn_gating (Cancellable? cancellable) throws GLib.Error;
 		public abstract async HostSpawnInfo[] enumerate_pending_spawn (Cancellable? cancellable) throws GLib.Error;
 		public abstract async uint spawn (string path, HostSpawnOptions options, Cancellable? cancellable) throws GLib.Error;

--- a/src/droidy/droidy-host-session.vala
+++ b/src/droidy/droidy-host-session.vala
@@ -521,6 +521,13 @@ namespace Frida {
 			}
 		}
 
+		// Forward the error untranslated so the caller can spot UNKNOWN_METHOD from an older remote.
+		public async void enable_spawn_gating_with_options (HashTable<string, Variant> options,
+				Cancellable? cancellable) throws Error, IOError {
+			var server = yield get_remote_server (cancellable);
+			yield server.session.enable_spawn_gating_with_options (options, cancellable);
+		}
+
 		public async void disable_spawn_gating (Cancellable? cancellable) throws Error, IOError {
 			var server = yield get_remote_server (cancellable);
 			try {
@@ -920,6 +927,7 @@ namespace Frida {
 			server.connection.on_closed.connect (on_remote_connection_closed);
 
 			var session = server.session;
+			session.spawn_gating_disabled.connect (on_remote_spawn_gating_disabled);
 			session.spawn_added.connect (on_remote_spawn_added);
 			session.spawn_removed.connect (on_remote_spawn_removed);
 			session.child_added.connect (on_remote_child_added);
@@ -934,6 +942,7 @@ namespace Frida {
 			server.connection.on_closed.disconnect (on_remote_connection_closed);
 
 			var session = server.session;
+			session.spawn_gating_disabled.disconnect (on_remote_spawn_gating_disabled);
 			session.spawn_added.disconnect (on_remote_spawn_added);
 			session.spawn_removed.disconnect (on_remote_spawn_removed);
 			session.child_added.disconnect (on_remote_child_added);
@@ -952,6 +961,10 @@ namespace Frida {
 			var no_crash = CrashInfo.empty ();
 			foreach (var remote_id in remote_agent_sessions.keys.to_array ())
 				on_remote_agent_session_detached (remote_id, CONNECTION_TERMINATED, no_crash);
+		}
+
+		private void on_remote_spawn_gating_disabled (SpawnGatingDisabledReason reason) {
+			spawn_gating_disabled (reason);
 		}
 
 		private void on_remote_spawn_added (HostSpawnInfo info) {

--- a/src/freebsd/freebsd-host-session.vala
+++ b/src/freebsd/freebsd-host-session.vala
@@ -77,7 +77,8 @@ namespace Frida {
 			return yield process_enumerator.enumerate_processes (ProcessQueryOptions._deserialize (options));
 		}
 
-		public override async void enable_spawn_gating (Cancellable? cancellable) throws Error, IOError {
+		public override async void enable_spawn_gating_with_options (HashTable<string, Variant> options,
+				Cancellable? cancellable) throws Error, IOError {
 			throw new Error.NOT_SUPPORTED ("Not yet supported on this OS");
 		}
 

--- a/src/frida.vala
+++ b/src/frida.vala
@@ -620,6 +620,14 @@ namespace Frida {
 	 */
 	public sealed class Device : Object {
 		/**
+		 * Emitted when spawn gating is disabled, either by request or because the host
+		 * cancelled it, e.g. a caught process was left unresumed long enough to risk
+		 * stalling process creation.
+		 *
+		 * @param reason why gating was disabled
+		 */
+		public signal void spawn_gating_disabled (SpawnGatingDisabledReason reason);
+		/**
 		 * Emitted when a process is spawned while spawn gating is enabled.
 		 *
 		 * @param spawn details of the pending spawn
@@ -1162,26 +1170,46 @@ namespace Frida {
 		/**
 		 * Enables spawn gating, suspending every newly spawned process until it
 		 * is explicitly resumed.
+		 *
+		 * @param options optional settings, e.g. how much to gate
 		 */
-		public async void enable_spawn_gating (Cancellable? cancellable = null) throws Error, IOError {
+		public async void enable_spawn_gating (SpawnGatingOptions? options = null,
+				Cancellable? cancellable = null) throws Error, IOError {
 			check_open ();
+
+			var scope = (options != null) ? options.scope : SpawnGatingScope.DEFAULT;
+			var raw_options = (options != null) ? options._serialize () : make_parameters_dict ();
 
 			var host_session = yield get_host_session (cancellable);
 
 			try {
-				yield host_session.enable_spawn_gating (cancellable);
+				yield host_session.enable_spawn_gating_with_options (raw_options, cancellable);
 			} catch (GLib.Error e) {
-				throw_dbus_error (e);
+				DBusError.strip_remote_error (e);
+				if (scope != DEFAULT || !(e is DBusError.UNKNOWN_METHOD))
+					throw_dbus_error (e);
+
+				// Older remote without the scoped call; fall back to the plain one (that's DEFAULT).
+				try {
+					yield host_session.enable_spawn_gating (cancellable);
+				} catch (GLib.Error legacy_error) {
+					throw_dbus_error (legacy_error);
+				}
 			}
 		}
 
-		public void enable_spawn_gating_sync (Cancellable? cancellable = null) throws Error, IOError {
-			create<EnableSpawnGatingTask> ().execute (cancellable);
+		public void enable_spawn_gating_sync (SpawnGatingOptions? options = null,
+				Cancellable? cancellable = null) throws Error, IOError {
+			var task = create<EnableSpawnGatingTask> ();
+			task.options = options;
+			task.execute (cancellable);
 		}
 
 		private class EnableSpawnGatingTask : DeviceTask<void> {
+			public SpawnGatingOptions? options;
+
 			protected override async void perform_operation () throws Error, IOError {
-				yield parent.enable_spawn_gating (cancellable);
+				yield parent.enable_spawn_gating (options, cancellable);
 			}
 		}
 
@@ -1750,6 +1778,7 @@ namespace Frida {
 		}
 
 		private void attach_host_session (HostSession session) {
+			session.spawn_gating_disabled.connect (on_spawn_gating_disabled);
 			session.spawn_added.connect (on_spawn_added);
 			session.spawn_removed.connect (on_spawn_removed);
 			session.child_added.connect (on_child_added);
@@ -1760,6 +1789,7 @@ namespace Frida {
 		}
 
 		private void detach_host_session (HostSession session) {
+			session.spawn_gating_disabled.disconnect (on_spawn_gating_disabled);
 			session.spawn_added.disconnect (on_spawn_added);
 			session.spawn_removed.disconnect (on_spawn_removed);
 			session.child_added.disconnect (on_child_added);
@@ -1883,6 +1913,10 @@ namespace Frida {
 				detach_request.resolve (true);
 			else if (session != null)
 				agent_sessions.unset (id);
+		}
+
+		private void on_spawn_gating_disabled (SpawnGatingDisabledReason reason) {
+			spawn_gating_disabled (reason);
 		}
 
 		private void on_spawn_added (HostSpawnInfo info) {

--- a/src/fruity/fruity-host-session.vala
+++ b/src/fruity/fruity-host-session.vala
@@ -742,6 +742,13 @@ namespace Frida {
 			}
 		}
 
+		// Forward the error untranslated so the caller can spot UNKNOWN_METHOD from an older remote.
+		public async void enable_spawn_gating_with_options (HashTable<string, Variant> options,
+				Cancellable? cancellable) throws Error, IOError {
+			var server = yield get_remote_server (cancellable);
+			yield server.session.enable_spawn_gating_with_options (options, cancellable);
+		}
+
 		public async void disable_spawn_gating (Cancellable? cancellable) throws Error, IOError {
 			var server = yield get_remote_server (cancellable);
 			try {
@@ -1426,6 +1433,7 @@ namespace Frida {
 			server.connection.on_closed.connect (on_remote_connection_closed);
 
 			var session = server.session;
+			session.spawn_gating_disabled.connect (on_remote_spawn_gating_disabled);
 			session.spawn_added.connect (on_remote_spawn_added);
 			session.spawn_removed.connect (on_remote_spawn_removed);
 			session.child_added.connect (on_remote_child_added);
@@ -1440,6 +1448,7 @@ namespace Frida {
 			server.connection.on_closed.disconnect (on_remote_connection_closed);
 
 			var session = server.session;
+			session.spawn_gating_disabled.disconnect (on_remote_spawn_gating_disabled);
 			session.spawn_added.disconnect (on_remote_spawn_added);
 			session.spawn_removed.disconnect (on_remote_spawn_removed);
 			session.child_added.disconnect (on_remote_child_added);
@@ -1458,6 +1467,10 @@ namespace Frida {
 			var no_crash = CrashInfo.empty ();
 			foreach (var remote_id in remote_agent_sessions.keys.to_array ())
 				on_remote_agent_session_detached (remote_id, CONNECTION_TERMINATED, no_crash);
+		}
+
+		private void on_remote_spawn_gating_disabled (SpawnGatingDisabledReason reason) {
+			spawn_gating_disabled (reason);
 		}
 
 		private void on_remote_spawn_added (HostSpawnInfo info) {

--- a/src/host-session-service.vala
+++ b/src/host-session-service.vala
@@ -484,7 +484,12 @@ namespace Frida {
 		public abstract async HostProcessInfo[] enumerate_processes (HashTable<string, Variant> options,
 			Cancellable? cancellable) throws Error, IOError;
 
-		public abstract async void enable_spawn_gating (Cancellable? cancellable) throws Error, IOError;
+		public async void enable_spawn_gating (Cancellable? cancellable) throws Error, IOError {
+			yield enable_spawn_gating_with_options (make_parameters_dict (), cancellable);
+		}
+
+		public abstract async void enable_spawn_gating_with_options (HashTable<string, Variant> options,
+			Cancellable? cancellable) throws Error, IOError;
 
 		public abstract async void disable_spawn_gating (Cancellable? cancellable) throws Error, IOError;
 

--- a/src/linux/linux-host-session.vala
+++ b/src/linux/linux-host-session.vala
@@ -77,6 +77,7 @@ namespace Frida {
 
 #if ANDROID
 			robo_launcher = new RoboLauncher (this, io_cancellable);
+			robo_launcher.gating_cancelled.connect (on_spawn_gating_cancelled);
 			robo_launcher.spawn_added.connect (on_spawn_added);
 			robo_launcher.spawn_removed.connect (on_spawn_removed);
 
@@ -97,6 +98,7 @@ namespace Frida {
 		public override async void close (Cancellable? cancellable) throws IOError {
 #if ANDROID
 			yield robo_launcher.close (cancellable);
+			robo_launcher.gating_cancelled.disconnect (on_spawn_gating_cancelled);
 			robo_launcher.spawn_added.disconnect (on_spawn_added);
 			robo_launcher.spawn_removed.disconnect (on_spawn_removed);
 
@@ -110,6 +112,7 @@ namespace Frida {
 #endif
 
 			if (spawn_gater != null) {
+				spawn_gater.gating_cancelled.disconnect (on_spawn_gating_cancelled);
 				spawn_gater.spawn_added.disconnect (on_spawn_added);
 				spawn_gater.spawn_removed.disconnect (on_spawn_removed);
 				spawn_gater.stop ();
@@ -276,25 +279,28 @@ namespace Frida {
 #endif
 		}
 
-		public override async void enable_spawn_gating (Cancellable? cancellable) throws Error, IOError {
+		public override async void enable_spawn_gating_with_options (HashTable<string, Variant> options,
+				Cancellable? cancellable) throws Error, IOError {
 			var helper_process = helper as LinuxHelperProcess;
 			if (helper_process != null)
 				yield helper_process.preload (cancellable);
 
-			var gater = ensure_spawn_gater ();
-			if (gater.state == STOPPED) {
 #if ANDROID
-				try {
+			// RoboLauncher gates app launches; only add the system-wide eBPF gater for PROCESSES.
+			// Let a start failure propagate — the caller opted in, so don't silently downgrade.
+			if (SpawnGatingOptions._deserialize (options).scope == PROCESSES) {
+				var gater = ensure_spawn_gater ();
+				if (gater.state == STOPPED)
 					gater.start ();
-				} catch (Error e) {
-				}
-#else
-				gater.start ();
-#endif
 			}
 
-#if ANDROID
 			yield robo_launcher.enable_spawn_gating (cancellable);
+#else
+			// No portable way to tell a GUI app from any other execve here, so both scopes map to
+			// the same system-wide gater.
+			var gater = ensure_spawn_gater ();
+			if (gater.state == STOPPED)
+				gater.start ();
 #endif
 		}
 
@@ -304,11 +310,14 @@ namespace Frida {
 #if ANDROID
 			yield robo_launcher.disable_spawn_gating (cancellable);
 #endif
+
+			spawn_gating_disabled (APPLICATION_REQUESTED);
 		}
 
 		private SpawnGater ensure_spawn_gater () {
 			if (spawn_gater == null) {
 				spawn_gater = new SpawnGater (helper);
+				spawn_gater.gating_cancelled.connect (on_spawn_gating_cancelled);
 				spawn_gater.spawn_added.connect (on_spawn_added);
 				spawn_gater.spawn_removed.connect (on_spawn_removed);
 			}
@@ -505,6 +514,10 @@ namespace Frida {
 			}
 		}
 #endif
+
+		private void on_spawn_gating_cancelled () {
+			spawn_gating_disabled (WATCHDOG_TIMEOUT);
+		}
 
 		private void on_spawn_added (HostSpawnInfo info) {
 			spawn_added (info);
@@ -1344,6 +1357,7 @@ namespace Frida {
 	}
 
 	private sealed class RoboLauncher : Object {
+		public signal void gating_cancelled ();
 		public signal void spawn_added (HostSpawnInfo info);
 		public signal void spawn_removed (HostSpawnInfo info);
 
@@ -1367,6 +1381,7 @@ namespace Frida {
 		private bool spawn_gating_enabled = false;
 		private Gee.HashMap<string, Promise<uint>> spawn_requests = new Gee.HashMap<string, Promise<uint>> ();
 		private Gee.HashMap<uint, HostSpawnInfo?> pending_spawn = new Gee.HashMap<uint, HostSpawnInfo?> ();
+		private SpawnGatingWatchdog watchdog = new SpawnGatingWatchdog ();
 
 		private delegate void CompletionNotify (GLib.Error? error);
 
@@ -1379,11 +1394,22 @@ namespace Frida {
 			);
 		}
 
+		construct {
+			watchdog.expired.connect (on_watchdog_expired);
+		}
+
+		private void on_watchdog_expired () {
+			disable_spawn_gating.begin (io_cancellable);
+			gating_cancelled ();
+		}
+
 		public async void preload (Cancellable? cancellable) throws Error, IOError {
 			yield ensure_loaded (cancellable);
 		}
 
 		public async void close (Cancellable? cancellable) throws IOError {
+			watchdog.clear ();
+
 			if (ensure_request != null) {
 				try {
 					yield ensure_loaded (cancellable);
@@ -1421,6 +1447,8 @@ namespace Frida {
 
 		public async void disable_spawn_gating (Cancellable? cancellable) throws Error, IOError {
 			spawn_gating_enabled = false;
+
+			watchdog.clear ();
 
 			var pending = pending_spawn.values.to_array ();
 			pending_spawn.clear ();
@@ -1508,8 +1536,10 @@ namespace Frida {
 			connection.resume.begin (io_cancellable);
 
 			HostSpawnInfo? info;
-			if (pending_spawn.unset (pid, out info))
+			if (pending_spawn.unset (pid, out info)) {
+				watchdog.cancel (pid);
 				spawn_removed (info);
+			}
 
 			return true;
 		}
@@ -2090,6 +2120,7 @@ namespace Frida {
 				} else if (spawn_gating_enabled) {
 					var spawn_info = HostSpawnInfo (hello.pid, hello.process_name);
 					pending_spawn[hello.pid] = spawn_info;
+					watchdog.arm (hello.pid);
 					spawn_added (spawn_info);
 					needs_resume = true;
 				}

--- a/src/linux/spawn-gater.vala
+++ b/src/linux/spawn-gater.vala
@@ -1,5 +1,6 @@
 namespace Frida {
 	public sealed class SpawnGater : Object {
+		public signal void gating_cancelled ();
 		public signal void spawn_added (HostSpawnInfo info);
 		public signal void spawn_removed (HostSpawnInfo info);
 
@@ -22,6 +23,7 @@ namespace Frida {
 		private State _state = STOPPED;
 
 		private Gee.Map<uint, HostSpawnInfo?> pending_spawn = new Gee.HashMap<uint, HostSpawnInfo?> ();
+		private SpawnGatingWatchdog watchdog = new SpawnGatingWatchdog ();
 
 		private BpfRingbufReader? events_reader;
 		private IOChannel? events_channel;
@@ -32,14 +34,28 @@ namespace Frida {
 		private const size_t RINGBUF_SIZE = 1U << 22;
 		private const size_t MAX_FILENAME = 256;
 
+		// bpf_send_signal(SIGSTOP) races our SIGCONT: one that lands first is dropped, so re-send
+		// until the task is observed running.
+		private const uint RESUME_MAX_ATTEMPTS = 20;
+		private const uint RESUME_RETRY_MSEC = 25;
+
 		public SpawnGater (LinuxHelper helper) {
 			Object (helper: helper);
+		}
+
+		construct {
+			watchdog.expired.connect (on_watchdog_expired);
 		}
 
 		protected override void dispose () {
 			stop ();
 
 			base.dispose ();
+		}
+
+		private void on_watchdog_expired () {
+			stop ();
+			gating_cancelled ();
 		}
 
 		public void start () throws Error {
@@ -86,6 +102,7 @@ namespace Frida {
 				perform_resume.begin (spawn.pid);
 			}
 			pending_spawn.clear ();
+			watchdog.clear ();
 
 			events_channel = null;
 			events_reader = null;
@@ -105,6 +122,7 @@ namespace Frida {
 			HostSpawnInfo? spawn;
 			if (!pending_spawn.unset (pid, out spawn))
 				return false;
+			watchdog.cancel (pid);
 			spawn_removed (spawn);
 			perform_resume.begin (pid);
 			return true;
@@ -115,8 +133,35 @@ namespace Frida {
 				yield helper.resume (pid, null);
 			} catch (GLib.Error e) {
 				if (e is Error.INVALID_ARGUMENT)
-					Posix.kill ((Posix.pid_t) pid, Posix.Signal.CONT);
+					yield resume_external (pid);
 			}
+		}
+
+		private async void resume_external (uint pid) {
+			for (uint attempt = 0; attempt != RESUME_MAX_ATTEMPTS; attempt++) {
+				if (Posix.kill ((Posix.pid_t) pid, Posix.Signal.CONT) != 0)
+					return;
+				if (!process_is_stopped (pid))
+					return;
+
+				var source = new TimeoutSource (RESUME_RETRY_MSEC);
+				source.set_callback (resume_external.callback);
+				source.attach (MainContext.get_thread_default ());
+				yield;
+			}
+		}
+
+		private static bool process_is_stopped (uint pid) {
+			string contents;
+			try {
+				FileUtils.get_contents ("/proc/%u/stat".printf (pid), out contents);
+			} catch (FileError e) {
+				return false;
+			}
+
+			// State is the char two past the final ')' (comm can itself contain ')').
+			char state = contents[contents.last_index_of_char (')') + 2];
+			return state == 'T' || state == 't';
 		}
 
 		private void process_pending_events () {
@@ -130,6 +175,7 @@ namespace Frida {
 		private void handle_event (ExecveEvent * e) {
 			var info = HostSpawnInfo (e->pid, (string) e->command);
 			pending_spawn[e->pid] = info;
+			watchdog.arm (e->pid);
 			spawn_added (info);
 		}
 

--- a/src/portal-service.vala
+++ b/src/portal-service.vala
@@ -787,7 +787,7 @@ namespace Frida {
 			return filtered_apps;
 		}
 
-		private void enable_spawn_gating (ControlChannel requester) {
+		private void enable_spawn_gating (HashTable<string, Variant> options, ControlChannel requester) {
 			spawn_gaters.add (requester);
 			foreach (PendingSpawn spawn in pending_spawn.values) {
 				bool requester_has_access = find_node_accessible_by (requester, spawn.info.pid) != null;
@@ -1409,7 +1409,12 @@ namespace Frida {
 			}
 
 			public async void enable_spawn_gating (Cancellable? cancellable) throws Error, IOError {
-				parent.enable_spawn_gating (this);
+				parent.enable_spawn_gating (make_parameters_dict (), this);
+			}
+
+			public async void enable_spawn_gating_with_options (HashTable<string, Variant> options,
+					Cancellable? cancellable) throws Error, IOError {
+				parent.enable_spawn_gating (options, this);
 			}
 
 			public async void disable_spawn_gating (Cancellable? cancellable) throws Error, IOError {

--- a/src/qnx/qnx-host-session.vala
+++ b/src/qnx/qnx-host-session.vala
@@ -74,7 +74,8 @@ namespace Frida {
 			return yield process_enumerator.enumerate_processes (ProcessQueryOptions._deserialize (options));
 		}
 
-		public override async void enable_spawn_gating (Cancellable? cancellable) throws Error, IOError {
+		public override async void enable_spawn_gating_with_options (HashTable<string, Variant> options,
+				Cancellable? cancellable) throws Error, IOError {
 			throw new Error.NOT_SUPPORTED ("Not yet supported on this OS");
 		}
 

--- a/src/simmy/simmy-host-session.vala
+++ b/src/simmy/simmy-host-session.vala
@@ -328,6 +328,11 @@ namespace Frida {
 			throw_not_supported ();
 		}
 
+		public async void enable_spawn_gating_with_options (HashTable<string, Variant> options,
+				Cancellable? cancellable) throws Error, IOError {
+			throw_not_supported ();
+		}
+
 		public async void disable_spawn_gating (Cancellable? cancellable) throws Error, IOError {
 			throw_not_supported ();
 		}

--- a/src/windows/windows-host-session.vala
+++ b/src/windows/windows-host-session.vala
@@ -164,7 +164,8 @@ namespace Frida {
 			return yield process_enumerator.enumerate_processes (ProcessQueryOptions._deserialize (options));
 		}
 
-		public override async void enable_spawn_gating (Cancellable? cancellable) throws Error, IOError {
+		public override async void enable_spawn_gating_with_options (HashTable<string, Variant> options,
+				Cancellable? cancellable) throws Error, IOError {
 			throw new Error.NOT_SUPPORTED ("Not yet supported on this OS");
 		}
 


### PR DESCRIPTION
17.8's system-wide eBPF spawn gater stops every execve and relies on the client to resume each caught spawn. If a client stops resuming, process creation wedges device-wide — an uninstall or `adb shell` hangs.

- **Fail-safe watchdog.** A shared `SpawnGatingWatchdog` cancels gating and resumes everything once a caught process is left unresumed too long, so a broken client can no longer deadlock the device. Wired into all four suspending gaters (Linux eBPF + RoboLauncher, iOS/tvOS launchd, macOS DTrace), plus a fix for the `bpf_send_signal(SIGSTOP)` vs `SIGCONT` resume race.
- **Notification.** A new `spawn_gating_disabled (reason)` `HostSession` signal, bubbled up to `Device`.
- **Opt-in scope.** `enable_spawn_gating` gains a `SpawnGatingScope` (`DEFAULT`/`APPLICATIONS`/`PROCESSES`); the potent system-wide gater now arms only for `PROCESSES`. Carried by a new `enable_spawn_gating_with_options`, keeping the wire protocol compatible with older Frida.
- **Bookkeeping.** Populates `ControlService`'s `pending_spawn`, which was never filled, restoring the multi-client approver model and resume-on-disable.

Builds on android-arm64, macos-arm64, and ios-arm64.
