### PR TITLE
compiler: Update Go toolchain to 1.24.13

### DIFF
--- a/src/compiler/go.mod
+++ b/src/compiler/go.mod
@@ -1,6 +1,6 @@
 module github.com/frida/frida-core-compiler
 
-go 1.24.3
+go 1.24.13
 
 require (
 	github.com/evanw/esbuild v0.25.5

--- a/src/compiler/symbol-replacer/go.mod
+++ b/src/compiler/symbol-replacer/go.mod
@@ -1,3 +1,3 @@
 module github.com/frida/frida-symbol-replacer
 
-go 1.24.3
+go 1.24.13

--- a/tools/cgo/go.mod
+++ b/tools/cgo/go.mod
@@ -1,3 +1,3 @@
 module frida.re/cgotest
 
-go 1.24.3
+go 1.24.13


### PR DESCRIPTION
Address CVEs reported in Go 1.24.3 standard library by bumping the required Go toolchain version to 1.24.13.